### PR TITLE
Implement GUI keyboard mapping

### DIFF
--- a/key_types.py
+++ b/key_types.py
@@ -1,7 +1,7 @@
 from enum import Enum, auto
 
 #Authoritative list of Actions. Any new key must be added here.
-class Action(str, Enum):         
+class Action(str, Enum):
     def _generate_next_value_(name, *_):
         return name #stringington city? shall we?             
     #physical keys, directly corresponding to pynput actions
@@ -42,3 +42,23 @@ class Action(str, Enum):
     predict_word   = auto()  # predictive text (common‑word) key placeholder
     predict_letter = auto()  # predictive text (common-letter) key placeholder
     #add your own
+
+    _VIRTUAL_ACTIONS = {
+        'page_next', 'page_prev', 'reset_scan_row',
+        'predict_word', 'predict_letter',
+    }
+
+    def is_virtual(self) -> bool:
+        """Return ``True`` if this action should not emit an OS key event."""
+        return self.name in self._VIRTUAL_ACTIONS
+
+    def to_os_key(self):
+        """Return the matching :class:`pynput.keyboard.Key` or ``None``."""
+        if self.is_virtual():
+            return None
+
+        from pynput.keyboard import Key as OSKey
+        try:
+            return getattr(OSKey, self.value)
+        except AttributeError:
+            return None

--- a/pc_control.py
+++ b/pc_control.py
@@ -1,8 +1,48 @@
+"""Mapping of GUI key actions to OS key events using :mod:`pynput`."""
+
 from pynput.keyboard import Key as OSKey, Controller
+
+from key_types import Action
 
 kb = Controller()
 
-def gui_to_controller(key):
-    pass
+def _send(key: OSKey | str) -> None:
+    """Press and release ``key`` using the global controller."""
 
-#connect kb_layout.Key to PynKey (with improved key_types.py)
+    kb.press(key)
+    kb.release(key)
+
+def gui_to_controller(key) -> None:
+    """Send the :mod:`pynput` events corresponding to ``key``.
+
+    ``key`` is a :class:`kb_layout.Key` instance.  If ``key.action`` refers to
+    one of the physical keys defined in :class:`Action`, the matching
+    :class:`pynput.keyboard.Key` is pressed and released.  Otherwise the textual
+    ``label`` of the key is typed character by character.  Virtual actions such
+    as :data:`Action.page_next` are ignored here and handled elsewhere.
+    """
+
+    action = getattr(key, "action", None)
+
+    # Convert a string action to ``Action`` if possible
+    if isinstance(action, str):
+        try:
+            action = Action[action]
+        except KeyError:
+            # Unknown action string - treat as None and fall back to label
+            action = None
+
+    if isinstance(action, Action):
+        if action.is_virtual():
+            # These actions are handled elsewhere and should not send OS events
+            return
+
+        os_key = action.to_os_key()
+        if os_key is not None:
+            _send(os_key)
+            return
+
+    # Fallback to typing the label as characters
+    for char in str(getattr(key, "label", "")):
+        _send(char)
+


### PR DESCRIPTION
## Summary
- refactor pc_control to use Action.to_os_key
- add Action.to_os_key helper method
- centralize virtual action handling

## Testing
- `python -m py_compile *.py`
- `python - <<'PY'
import os
os.environ['PYNPUT_BACKEND'] = 'dummy'
from kb_layout import Key
from pc_control import gui_to_controller
try:
    gui_to_controller(Key('a'))
except NotImplementedError:
    pass
print('done')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6854a1c48d948333b58fd79c069e81a5