### PR TITLE
Fix leftover frames on page change

### DIFF
--- a/kb_gui.py
+++ b/kb_gui.py
@@ -85,8 +85,9 @@ class VirtualKeyboard:
             widget.config(bg=self._bg_for_key(k))
 
     def render_page(self):
-        for widget, _ in self.key_widgets:
-            widget.destroy()
+        # clear out old widgets from the frame before rendering the new page
+        for child in self.page_frame.winfo_children():
+            child.destroy()
         self.key_widgets.clear()
         self.row_start_indices.clear()
         self.row_indices.clear()


### PR DESCRIPTION
## Summary
- clean up page frame before rebuilding the virtual keyboard page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6855ab19e36c8333a8627bc0e841ded6