### PR TITLE
Add row_start_for_index helper

### DIFF
--- a/kb_gui.py
+++ b/kb_gui.py
@@ -67,6 +67,11 @@ class VirtualKeyboard:
             self.current_page -= 1
             self.render_page()
 
+    def row_start_for_index(self, index: int) -> int:
+        """Return the first key index of the row containing ``index``."""
+        row = self.row_indices[index]
+        return self.row_start_indices[row]
+
     # ───────── internal helpers ───────────────────────────────────────────
     def _bg_for_key(self, key: Key) -> str:
         if key.mode == "toggle" and key.action == "caps_lock" and self.caps_on:


### PR DESCRIPTION
## Summary
- add `row_start_for_index` helper to `VirtualKeyboard`
- compile repo to ensure syntax OK

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855abe714708333b22b60040997b055