### PR TITLE
Remove default keyboard import

### DIFF
--- a/kb_gui.py
+++ b/kb_gui.py
@@ -1,6 +1,5 @@
 import tkinter as tk
 from kb_layout import Keyboard, Key
-from kb_layout_io import load_keyboard, FILE
 from pc_control import gui_to_controller
 
 class VirtualKeyboard:

--- a/kb_layout_io.py
+++ b/kb_layout_io.py
@@ -32,5 +32,3 @@ def load_keyboard(path: str = FILE) -> Keyboard:
         page_objects.append(KeyboardPage(row_objects))
 
     return Keyboard(page_objects)
-
-kb = load_keyboard(FILE)


### PR DESCRIPTION
## Summary
- avoid side effects on import by removing the global `kb` from `kb_layout_io`
- tidy `kb_gui` imports

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `flake8` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_6855abfb491c83339feb7e78121346b5