### PR TITLE
Fix predictive text completion behavior

### DIFF
--- a/kb_gui.py
+++ b/kb_gui.py
@@ -54,7 +54,8 @@ class VirtualKeyboard:
 
         send_key = key
         if action == Action.predict_word:
-            send_key = SimpleNamespace(label=label, action=action, mode=mode)
+            completion = label[len(self.current_word):] if label.startswith(self.current_word) else label
+            send_key = SimpleNamespace(label=completion, action=action, mode=mode)
         self.on_key(send_key)                    # hand to pc_control
 
         # update current word buffer

--- a/pc_control.py
+++ b/pc_control.py
@@ -24,7 +24,8 @@ def gui_to_controller(key):
 
     # Predictive-text key: send the suggested word then a space
     if action == Action.predict_word:
-        kb.type(label + " ")
+        if label:
+            kb.type(label + " ")
         return
 
     os_key = None


### PR DESCRIPTION
## Summary
- make predicted word insert the remaining letters only
- avoid typing predicted words when there is no suggestion

## Testing
- `python -m py_compile kb_gui.py pc_control.py`

------
https://chatgpt.com/codex/tasks/task_e_6866e9a87a248333886086a469d36cdd