### PR TITLE
Move scanner logic to Tk thread

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,17 +5,27 @@ from pc_control    import gui_to_controller
 from scan_engine   import Scanner
 from detection     import listen
 import threading
+from queue import SimpleQueue
 
 # ── GUI & Scanner ───────────────────────────────────────────────────────────────
 vk = VirtualKeyboard(load_keyboard(FILE), on_key=gui_to_controller)
 scanner = Scanner(vk, dwell=0.6)
 scanner.start()
 
+press_queue = SimpleQueue()
+
 # ── Detection hook ─────────────────────────────────────────────────────────────
+
 def _on_switch():
-    vk.root.after(0, scanner.on_press)
+    press_queue.put(None)
+
+def _pump_queue():
+    while not press_queue.empty():
+        scanner.on_press()
+    vk.root.after(10, _pump_queue)
 
 threading.Thread(target=listen, args=(_on_switch,), daemon=True).start()
+vk.root.after(10, _pump_queue)
 
 # ── Main loop ───────────────────────────────────────────────────────────────────
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- run scanner highlighting loop using Tk `after` callbacks
- pump switch events through a queue instead of calling into Tk from the audio thread

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6866f09becfc83339d843a80bfaa09c4