### PR TITLE
Implement n-gram letter prediction

### DIFF
--- a/myproject/pc_control.py
+++ b/myproject/pc_control.py
@@ -22,10 +22,14 @@ def gui_to_controller(key):
     if isinstance(action, str):
         action = Action.__members__.get(action)
 
-    # Predictive-text key: send the suggested word then a space
+    # Predictive-text keys
     if action == Action.predict_word:
         if label:
             kb.type(label + " ")
+        return
+    if action == Action.predict_letter:
+        if label:
+            kb.type(label)
         return
 
     os_key = None

--- a/myproject/predictive.py
+++ b/myproject/predictive.py
@@ -1,11 +1,62 @@
+"""Simple predictive text helpers."""
+
+from collections import Counter, defaultdict
 from functools import lru_cache
+from typing import Counter as CounterType, DefaultDict
+
 from wordfreq import top_n_list
 
-_WORDS = top_n_list("en", 80_000)          # ranked common words
+# Preload a large list of common English words. 80k keeps startup reasonable
+# while providing decent coverage for prediction.
+_WORDS = top_n_list("en", 80_000)  # ranked common words
+
+
+# ───────── letter n‑gram models ────────────────────────────────────────────
+
+# Frequency of starting letters for words
+_START_LETTERS: CounterType[str] = Counter()
+
+# Bigram and trigram counts.  ``_BIGRAMS['h']['e']`` counts how often
+# "he" occurs, while ``_TRIGRAMS['th']['e']`` counts occurrences of "the".
+_BIGRAMS: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
+_TRIGRAMS: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
+
+for word in _WORDS:
+    w = "".join(c for c in word.lower() if c.isalpha())
+    if not w:
+        continue
+    _START_LETTERS[w[0]] += 1
+    for a, b in zip(w, w[1:]):
+        _BIGRAMS[a][b] += 1
+    for a, b, c in zip(w, w[1:], w[2:]):
+        _TRIGRAMS[a + b][c] += 1
+
+
+# ───────── public API ─────────────────────────────────────────────────────
 
 @lru_cache(maxsize=2048)
-def suggest(prefix: str, k: int = 3) -> list[str]:
+def suggest_words(prefix: str, k: int = 3) -> list[str]:
+    """Return up to ``k`` common words starting with ``prefix``."""
+
     if not prefix:
         return []
     p = prefix.lower()
     return [w for w in _WORDS if w.startswith(p)][:k]
+
+
+@lru_cache(maxsize=2048)
+def suggest_letters(prefix: str, k: int = 3) -> list[str]:
+    """Suggest up to ``k`` likely next letters for ``prefix``."""
+
+    cleaned = "".join(c for c in prefix.lower() if c.isalpha())
+    if not cleaned:
+        source = _START_LETTERS
+    else:
+        last2 = cleaned[-2:]
+        if len(last2) == 2 and last2 in _TRIGRAMS:
+            source = _TRIGRAMS[last2]
+        else:
+            last1 = cleaned[-1]
+            source = _BIGRAMS.get(last1, _START_LETTERS)
+
+    return [l for l, _ in source.most_common(k)]

--- a/myproject/resources/layouts/pred_test.json
+++ b/myproject/resources/layouts/pred_test.json
@@ -10,6 +10,13 @@
           ]
         },
         {
+          "stretch": true, "keys": [
+            {"label": "", "action": "predict_letter"},
+            {"label": "", "action": "predict_letter"},
+            {"label": "", "action": "predict_letter"}
+          ]
+        },
+        {
           "keys": [
             {"label": "a"}, {"label": "b"}, {"label": "c"}, {"label": "d"}, {"label": "e"}
           ]

--- a/tests/test_predictive.py
+++ b/tests/test_predictive.py
@@ -1,0 +1,8 @@
+import myproject.predictive as predictive
+
+
+def test_letter_suggestion():
+    letters = predictive.suggest_letters("th")
+    assert isinstance(letters, list)
+    assert len(letters) > 0
+    assert all(isinstance(c, str) and len(c) == 1 for c in letters)


### PR DESCRIPTION
## Summary
- build simple n‑gram model for predictive text
- expose `suggest_letters` and `suggest_words`
- support `predict_letter` action in GUI and controller
- add letter prediction row to default layout
- test predictive letter helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867179e9c748333bfa466b22e65a5a8