### PR TITLE
Fix scanner reset skipping first key

### DIFF
--- a/myproject/scan_engine.py
+++ b/myproject/scan_engine.py
@@ -40,10 +40,13 @@ class Scanner:
 
     def _tick(self) -> None:
         if not self.row_column_scan:
-            idx = self.keyboard.highlight_index
+            idx = self.key_cursor
+            self.keyboard.highlight_index = idx
             _, key = self.keyboard.key_widgets[idx]
             dwell_ms = int(self.dwell * 1000 * (key.dwell_mult or 1))
-            self.keyboard.advance_highlight()
+            next_idx = (idx + 1) % len(self.keyboard.key_widgets)
+            self.key_cursor = next_idx
+            self.keyboard._update_highlight()
             self._after_id = self.keyboard.root.after(dwell_ms, self._tick)
             return
 
@@ -111,6 +114,7 @@ class Scanner:
             _activate_highlighted()
             if self.reset_after_press:
                 self.keyboard.highlight_index = 0
+                self.key_cursor = 0
                 self.keyboard._update_highlight()
 
         if self._after_id is not None:

--- a/tests/test_scan_engine.py
+++ b/tests/test_scan_engine.py
@@ -72,3 +72,19 @@ def test_row_column_scanning_flow():
     assert kb.pressed == [3]
     assert scanner.phase == ScanPhase.ROW
     assert kb.highlight_row_index == 0
+
+
+def test_reset_after_press_starts_from_first_key():
+    kb = DummyKeyboard()
+    scanner = Scanner(kb, dwell=0.1)
+    scanner.start()
+    # advance once to highlight index 1
+    kb.root.scheduled.pop(0)()
+    assert kb.highlight_index == 1
+    # activate current key
+    scanner.on_press()
+    assert kb.pressed == [1]
+    assert kb.highlight_index == 0
+    # next tick should move to key 1
+    kb.root.scheduled.pop(0)()
+    assert kb.highlight_index == 1


### PR DESCRIPTION
## Summary
- fix scanning logic so first key isn't skipped when resetting
- update the scanner press logic to reset the cursor
- add regression test for scanning reset behaviour

## Testing
- `pip install wordfreq`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868564490c48333ae1f5bf172d9e8c2