### PR TITLE
Add WASAPI exclusive mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The CLI also accepts optional flags:
 - `--dwell SECONDS` — how long each key remains highlighted (default: 0.6).
 - `--row-column` — use row/column scanning instead of linear scanning.
 
+On Windows the microphone is opened in WASAPI exclusive mode when possible. If
+exclusive access fails, the program falls back to the default shared mode.
+
 ### Layout files
 
 Layouts live in `myproject/resources/layouts/`. Each JSON file defines `pages` containing rows of `keys`. Keys can specify a label and an action. The `pred_test.json` layout includes special `predict_word` and `predict_letter` keys that pull suggestions from the built‑in predictive text engine.

--- a/myproject/audio/wasapi.py
+++ b/myproject/audio/wasapi.py
@@ -1,0 +1,24 @@
+"""Windows WASAPI helpers.
+
+`get_extra_settings()` returns `sd.WasapiSettings(exclusive=True)` when the
+current host API's name is ``"Windows WASAPI"``. If the host API differs or
+any error occurs, ``None`` is returned so callers can fall back to shared
+mode gracefully.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import sounddevice as sd
+
+
+def get_extra_settings() -> Optional[sd.WasapiSettings]:
+    """Return exclusive-mode settings for WASAPI if available."""
+    try:
+        info = sd.query_hostapis(sd.default.hostapi)
+        if info.get("name") == "Windows WASAPI":
+            return sd.WasapiSettings(exclusive=True)
+    except Exception:
+        pass
+    return None

--- a/tests/test_wasapi.py
+++ b/tests/test_wasapi.py
@@ -1,0 +1,75 @@
+import importlib
+import sys
+import types
+
+
+def _reload_with_dummy_sd(monkeypatch, sd_mod):
+    monkeypatch.setitem(sys.modules, "sounddevice", sd_mod)
+    import myproject.audio.wasapi as wasapi
+    importlib.reload(wasapi)
+    return wasapi
+
+
+def test_get_extra_settings_only_for_wasapi(monkeypatch):
+    class DummySettings:
+        def __init__(self, exclusive=False):
+            self.exclusive = exclusive
+
+    sd_mod = types.SimpleNamespace(
+        WasapiSettings=DummySettings,
+        query_hostapis=lambda idx: {"name": "Windows WASAPI"},
+        default=types.SimpleNamespace(hostapi=0),
+    )
+    wasapi = _reload_with_dummy_sd(monkeypatch, sd_mod)
+    assert isinstance(wasapi.get_extra_settings(), DummySettings)
+
+    sd_mod.query_hostapis = lambda idx: {"name": "Other"}
+    wasapi = _reload_with_dummy_sd(monkeypatch, sd_mod)
+    assert wasapi.get_extra_settings() is None
+
+
+def test_listen_retries_shared_mode(monkeypatch):
+    calls = []
+    fail = {"flag": True}
+
+    class DummySettings:
+        def __init__(self, exclusive=True):
+            self.exclusive = exclusive
+
+    class PortAudioError(Exception):
+        pass
+
+    def InputStream(**kwargs):
+        calls.append(kwargs)
+        if fail["flag"] and "extra_settings" in kwargs:
+            fail["flag"] = False
+            raise PortAudioError("fail")
+
+        class _Ctx:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        return _Ctx()
+
+    sd_mod = types.SimpleNamespace(
+        WasapiSettings=DummySettings,
+        PortAudioError=PortAudioError,
+        InputStream=InputStream,
+        query_hostapis=lambda idx: {"name": "Windows WASAPI"},
+        default=types.SimpleNamespace(hostapi=0),
+    )
+
+    wasapi = _reload_with_dummy_sd(monkeypatch, sd_mod)
+    import myproject.detection as detection
+    importlib.reload(detection)
+
+    monkeypatch.setattr(detection.time, "sleep", lambda _: (_ for _ in ()).throw(KeyboardInterrupt))
+
+    detection.listen(lambda: None, samplerate=1, blocksize=1)
+
+    assert len(calls) == 2
+    assert "extra_settings" in calls[0]
+    assert "extra_settings" not in calls[1]


### PR DESCRIPTION
## Summary
- implement audio.wasapi.get_extra_settings to request WASAPI exclusive mode
- open InputStream with optional extra_settings and retry on failure
- document Windows exclusive mode fallback in README
- test exclusive-mode fallback and helper function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686886707434833382cafe2f78743b4d