### PR TITLE
Introduce PCController

### DIFF
--- a/myproject/__main__.py
+++ b/myproject/__main__.py
@@ -10,7 +10,7 @@ from queue import Empty, SimpleQueue
 from .detection import listen
 from .kb_gui import VirtualKeyboard
 from .kb_layout_io import load_keyboard
-from .pc_control import gui_to_controller, state
+from .pc_control import PCController
 from .scan_engine import Scanner
 
 
@@ -37,8 +37,9 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
+    pc_controller = PCController()
     vk = VirtualKeyboard(
-        load_keyboard(args.layout), on_key=gui_to_controller, state=state
+        load_keyboard(args.layout), on_key=pc_controller.on_key, state=pc_controller.state
     )
     scanner = Scanner(vk, dwell=args.dwell, row_column_scan=args.row_column)
     scanner.start()

--- a/myproject/pc_control.py
+++ b/myproject/pc_control.py
@@ -2,72 +2,73 @@ from pynput.keyboard import Key as OSKey, Controller
 from .key_types import Action
 from .modifier_state import ModifierState
 
-kb = Controller()
 
-# single source of truth for modifier state
-state = ModifierState()
+class PCController:
+    """Translate :class:`~myproject.kb_gui.Key` objects into OS key events."""
 
+    def __init__(self, kb: Controller | None = None, state: ModifierState | None = None) -> None:
+        self.kb = kb or Controller()
+        # single source of truth for modifier state
+        self.state = state or ModifierState()
 
-def _tap(k: OSKey | str):
-    kb.press(k)
-    kb.release(k)
+    def _tap(self, k: OSKey | str) -> None:
+        self.kb.press(k)
+        self.kb.release(k)
 
+    def on_key(self, key) -> None:
+        action = getattr(key, "action", None)
+        mode = getattr(key, "mode", "tap")
+        label = getattr(key, "label", "")
 
-def gui_to_controller(key):
+        if isinstance(action, str):
+            action = Action.__members__.get(action)
 
-    action = getattr(key, "action", None)
-    mode = getattr(key, "mode", "tap")
-    label = getattr(key, "label", "")
+        # Predictive-text keys
+        if action == Action.predict_word:
+            if label:
+                self.kb.type(label + " ")
+            return
+        if action == Action.predict_letter:
+            if label:
+                self.kb.type(label)
+            return
 
-    if isinstance(action, str):
-        action = Action.__members__.get(action)
+        os_key = None
+        if isinstance(action, Action) and not action.is_virtual():
+            os_key = action.to_os_key()
 
-    # Predictive-text keys
-    if action == Action.predict_word:
-        if label:
-            kb.type(label + " ")
-        return
-    if action == Action.predict_letter:
-        if label:
-            kb.type(label)
-        return
+        # Toggle modifiers (Caps Lock, etc.)
+        if mode == "toggle" and os_key:
+            active = self.state.toggle(os_key)
+            if active:
+                self.kb.press(os_key)
+            else:
+                self.kb.release(os_key)
+            return
 
-    os_key = None
-    if isinstance(action, Action) and not action.is_virtual():
-        os_key = action.to_os_key()
+        # Latch modifiers (one-shot Shift / Ctrl / Alt)
+        if mode == "latch" and os_key:
+            prev = self.state._latched
+            self.state.latch(os_key)
+            if prev:
+                self.kb.release(prev)
+            if self.state._latched:
+                self.kb.press(self.state._latched)
+            else:
+                self.kb.release(os_key)
+            return
 
-    # Toggle modifiers (Caps Lock, etc.)
-    if mode == "toggle" and os_key:
-        active = state.toggle(os_key)
-        if active:
-            kb.press(os_key)
+        # Normal tap; apply latched modifier once if present
+        def send_payload() -> None:
+            if os_key is not None:
+                self._tap(os_key)
+            else:
+                self.kb.type(str(label))
+
+        latched = self.state.consume_latch()
+        if latched:
+            self.kb.press(latched)
+            send_payload()
+            self.kb.release(latched)
         else:
-            kb.release(os_key)
-        return
-
-    # Latch modifiers (one-shot Shift / Ctrl / Alt)
-    if mode == "latch" and os_key:
-        prev = state._latched
-        state.latch(os_key)
-        if prev:
-            kb.release(prev)
-        if state._latched:
-            kb.press(state._latched)
-        else:
-            kb.release(os_key)
-        return
-
-    # Normal tap; apply latched modifier once if present
-    def send_payload():
-        if os_key is not None:
-            _tap(os_key)
-        else:
-            kb.type(str(label))
-
-    latched = state.consume_latch()
-    if latched:
-        kb.press(latched)
-        send_payload()
-        kb.release(latched)
-    else:
-        send_payload()
+            send_payload()

--- a/tests/test_pc_control.py
+++ b/tests/test_pc_control.py
@@ -1,6 +1,5 @@
 import types
-from myproject import pc_control
-from myproject.modifier_state import ModifierState
+from myproject.pc_control import PCController
 from pynput.keyboard import Key as OSKey
 
 class DummyKB:
@@ -13,18 +12,17 @@ class DummyKB:
     def type(self, t):
         self.events.append(("type", t))
 
-def test_shift_latch_sequence(monkeypatch):
+def test_shift_latch_sequence():
     kb = DummyKB()
-    monkeypatch.setattr(pc_control, "kb", kb)
-    pc_control.state = ModifierState()
+    controller = PCController(kb=kb)
 
     shift_key = types.SimpleNamespace(label="shift", action="shift", mode="latch")
     a_key = types.SimpleNamespace(label="a", action=None, mode="tap")
     b_key = types.SimpleNamespace(label="b", action=None, mode="tap")
 
-    pc_control.gui_to_controller(shift_key)
-    pc_control.gui_to_controller(a_key)
-    pc_control.gui_to_controller(b_key)
+    controller.on_key(shift_key)
+    controller.on_key(a_key)
+    controller.on_key(b_key)
 
     events = kb.events
     assert events[0] == ("press", OSKey.shift)


### PR DESCRIPTION
## Summary
- move GUI to controller logic into a new `PCController` class
- update entrypoint to use the controller instance
- adjust pc_control unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac098e5888333b5875385eb5c5944