### PR TITLE
Add interface abstractions

### DIFF
--- a/myproject/interfaces.py
+++ b/myproject/interfaces.py
@@ -1,0 +1,47 @@
+"""Interface definitions to decouple core components."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class KeyReceiver(Protocol):
+    """Object capable of handling a key activation."""
+
+    def on_key(self, key: Any) -> None:
+        """Process an activated key."""
+        ...
+
+
+@runtime_checkable
+class ScannableKeyboard(Protocol):
+    """Minimal API required by :class:`Scanner`."""
+
+    root: Any
+    highlight_index: int
+    highlight_row_index: int | None
+    key_widgets: list[tuple[Any, Any]]
+    row_start_indices: list[int]
+    row_indices: list[int]
+
+    def advance_highlight(self) -> None:
+        ...
+
+    def press_highlighted(self) -> None:
+        ...
+
+    def next_page(self) -> None:
+        ...
+
+    def prev_page(self) -> None:
+        ...
+
+    def row_start_for_index(self, index: int) -> int:
+        ...
+
+    def highlight_row(self, row_idx: int | None) -> None:
+        ...
+
+    def _update_highlight(self) -> None:
+        ...

--- a/myproject/pc_control.py
+++ b/myproject/pc_control.py
@@ -1,9 +1,10 @@
 from pynput.keyboard import Key as OSKey, Controller
+from .interfaces import KeyReceiver
 from .key_types import Action
 from .modifier_state import ModifierState
 
 
-class PCController:
+class PCController(KeyReceiver):
     """Translate :class:`~myproject.kb_gui.Key` objects into OS key events."""
 
     def __init__(self, kb: Controller | None = None, state: ModifierState | None = None) -> None:

--- a/myproject/scan_engine.py
+++ b/myproject/scan_engine.py
@@ -1,7 +1,7 @@
 from enum import Enum, auto
 from typing import Optional
 
-from .kb_gui import VirtualKeyboard
+from .interfaces import ScannableKeyboard
 from .key_types import Action
 
 
@@ -13,7 +13,7 @@ class ScanPhase(Enum):
 class Scanner:
     def __init__(
         self,
-        keyboard: VirtualKeyboard,
+        keyboard: ScannableKeyboard,
         dwell: float = 1.0,
         reset_after_press: bool = True,
         row_column_scan: bool = False,


### PR DESCRIPTION
## Summary
- define `KeyReceiver` and `ScannableKeyboard` interfaces
- implement `PCController` as `KeyReceiver`
- use `ScannableKeyboard` in `Scanner`

## Testing
- `pip install wordfreq pynput`
- `pip install numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac578d10c8333b9daebf6dd289b0a