### PR TITLE
Lazy-load n-gram models

### DIFF
--- a/switch_interface/predictive.py
+++ b/switch_interface/predictive.py
@@ -5,32 +5,84 @@ from functools import lru_cache
 from typing import Counter as CounterType
 from typing import DefaultDict
 
+import threading
+
 from wordfreq import top_n_list
 
 # Preload a large list of common English words. 80k keeps startup reasonable
 # while providing decent coverage for prediction.
 _WORDS = top_n_list("en", 80_000)  # ranked common words
 
+# Basic frequency of starting letters for fallback predictions
+_FALLBACK_STARTS = Counter(w[0] for w in _WORDS if w and w[0].isalpha())
+
 
 # ───────── letter n‑gram models ────────────────────────────────────────────
 
 # Frequency of starting letters for words
-_START_LETTERS: CounterType[str] = Counter()
+_START_LETTERS: CounterType[str] | None = None
 
 # Bigram and trigram counts.  ``_BIGRAMS['h']['e']`` counts how often
 # "he" occurs, while ``_TRIGRAMS['th']['e']`` counts occurrences of "the".
-_BIGRAMS: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
-_TRIGRAMS: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
+_BIGRAMS: DefaultDict[str, CounterType[str]] | None = None
+_TRIGRAMS: DefaultDict[str, CounterType[str]] | None = None
 
-for word in _WORDS:
-    w = "".join(c for c in word.lower() if c.isalpha())
-    if not w:
-        continue
-    _START_LETTERS[w[0]] += 1
-    for a, b in zip(w, w[1:]):
-        _BIGRAMS[a][b] += 1
-    for a, b, c in zip(w, w[1:], w[2:]):
-        _TRIGRAMS[a + b][c] += 1
+_READY = False
+_THREAD: threading.Thread | None = None
+_LOCK = threading.Lock()
+
+
+def _build_ngrams() -> None:
+    start_letters: CounterType[str] = Counter()
+    bigrams: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
+    trigrams: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
+
+    for word in _WORDS:
+        w = "".join(c for c in word.lower() if c.isalpha())
+        if not w:
+            continue
+        start_letters[w[0]] += 1
+        for a, b in zip(w, w[1:]):
+            bigrams[a][b] += 1
+        for a, b, c in zip(w, w[1:], w[2:]):
+            trigrams[a + b][c] += 1
+
+    global _START_LETTERS, _BIGRAMS, _TRIGRAMS, _READY
+    _START_LETTERS = start_letters
+    _BIGRAMS = bigrams
+    _TRIGRAMS = trigrams
+    _READY = True
+
+
+def _ensure_thread() -> None:
+    """Kick off n-gram building in the background if not already running."""
+
+    global _THREAD
+    if _READY or _THREAD is not None:
+        return
+    with _LOCK:
+        if _THREAD is None and not _READY:
+            _THREAD = threading.Thread(target=_build_ngrams, daemon=True)
+            _THREAD.start()
+
+
+def _fallback_letters(prefix: str, k: int) -> list[str]:
+    cleaned = "".join(c for c in prefix.lower() if c.isalpha())
+
+    counts = Counter()
+    if not cleaned:
+        counts = _FALLBACK_STARTS
+    else:
+        n = len(cleaned)
+        for w in _WORDS:
+            if w.startswith(cleaned) and len(w) > n:
+                c = w[n]
+                if c.isalpha():
+                    counts[c] += 1
+        if not counts:
+            counts = _FALLBACK_STARTS
+
+    return [c for c, _ in counts.most_common(k)]
 
 
 # ───────── public API ─────────────────────────────────────────────────────
@@ -39,6 +91,7 @@ for word in _WORDS:
 @lru_cache(maxsize=2048)
 def suggest_words(prefix: str, k: int = 3) -> list[str]:
     """Return up to ``k`` common words starting with ``prefix``."""
+    _ensure_thread()
 
     if not prefix:
         return []
@@ -49,16 +102,23 @@ def suggest_words(prefix: str, k: int = 3) -> list[str]:
 @lru_cache(maxsize=2048)
 def suggest_letters(prefix: str, k: int = 3) -> list[str]:
     """Suggest up to ``k`` likely next letters for ``prefix``."""
+    _ensure_thread()
+
+    if not _READY:
+        return _fallback_letters(prefix, k)
 
     cleaned = "".join(c for c in prefix.lower() if c.isalpha())
     if not cleaned:
+        assert _START_LETTERS is not None
         source = _START_LETTERS
     else:
         last2 = cleaned[-2:]
-        if len(last2) == 2 and last2 in _TRIGRAMS:
+        if len(last2) == 2 and _TRIGRAMS is not None and last2 in _TRIGRAMS:
             source = _TRIGRAMS[last2]
         else:
             last1 = cleaned[-1]
+            assert _BIGRAMS is not None and _START_LETTERS is not None
             source = _BIGRAMS.get(last1, _START_LETTERS)
 
     return [letter for letter, _ in source.most_common(k)]
+

--- a/tests/test_predictive.py
+++ b/tests/test_predictive.py
@@ -1,3 +1,4 @@
+import importlib
 import switch_interface.predictive as predictive
 
 
@@ -6,3 +7,13 @@ def test_letter_suggestion():
     assert isinstance(letters, list)
     assert len(letters) > 0
     assert all(isinstance(c, str) and len(c) == 1 for c in letters)
+
+
+def test_ngram_thread_starts_on_demand(monkeypatch):
+    importlib.reload(predictive)
+    assert predictive._THREAD is None
+
+    letters = predictive.suggest_letters("an")
+    assert len(letters) > 0
+    assert predictive._THREAD is not None
+


### PR DESCRIPTION
## Summary
- build predictive n-gram models asynchronously and on demand
- add fallback letter prediction logic
- test that the n-gram thread starts when suggestions are requested

## Testing
- `pip install -e .`
- `pip install numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac9ad951c8333bf11916c16a9fd22