### PR TITLE
Refactor predictive initialization

### DIFF
--- a/switch_interface/kb_gui.py
+++ b/switch_interface/kb_gui.py
@@ -6,16 +6,23 @@ from typing import Callable
 from .kb_layout import Key, Keyboard
 from .key_types import Action
 from .modifier_state import ModifierState
-from .predictive import suggest_letters, suggest_words
+from .predictive import Predictor, default_predictor
 
 
 class VirtualKeyboard:
     """Render a Keyboard as labels you cycle through and press programmatically."""
 
-    def __init__(self, keyboard: Keyboard, on_key: Callable, state: ModifierState):
+    def __init__(
+        self,
+        keyboard: Keyboard,
+        on_key: Callable,
+        state: ModifierState,
+        predictor: Predictor | None = None,
+    ):
         self.keyboard = keyboard
         self.on_key = on_key
         self.state = state
+        self.predictor = predictor or default_predictor
 
         self.current_page = 0
         self.highlight_index = 0
@@ -142,8 +149,8 @@ class VirtualKeyboard:
             widget.config(bg=self._bg_for_key(k))
 
     def _update_predictions(self):
-        words = suggest_words(self.current_word, 3)
-        letters = suggest_letters(self.current_word, 3)
+        words = self.predictor.suggest_words(self.current_word, 3)
+        letters = self.predictor.suggest_letters(self.current_word, 3)
         word_idx = 0
         letter_idx = 0
         for widget, k in self.key_widgets:

--- a/switch_interface/predictive.py
+++ b/switch_interface/predictive.py
@@ -1,124 +1,134 @@
-"""Simple predictive text helpers."""
+"""Simple predictive text helpers without module-level state."""
+
+from __future__ import annotations
 
 from collections import Counter, defaultdict
 from functools import lru_cache
-from typing import Counter as CounterType
-from typing import DefaultDict
+from typing import Counter as CounterType, DefaultDict
 
 import threading
 
 from wordfreq import top_n_list
 
-# Preload a large list of common English words. 80k keeps startup reasonable
-# while providing decent coverage for prediction.
-_WORDS = top_n_list("en", 80_000)  # ranked common words
 
-# Basic frequency of starting letters for fallback predictions
-_FALLBACK_STARTS = Counter(w[0] for w in _WORDS if w and w[0].isalpha())
+class Predictor:
+    """Generate common word and letter suggestions."""
 
+    def __init__(self, words: list[str] | None = None) -> None:
+        self.words = words or top_n_list("en", 80_000)
+        self.fallback_starts = Counter(
+            w[0] for w in self.words if w and w[0].isalpha()
+        )
+        self.start_letters: CounterType[str] | None = None
+        self.bigrams: DefaultDict[str, CounterType[str]] | None = None
+        self.trigrams: DefaultDict[str, CounterType[str]] | None = None
+        self.ready = False
+        self.thread: threading.Thread | None = None
+        self.lock = threading.Lock()
 
-# ───────── letter n‑gram models ────────────────────────────────────────────
+    # ───────── internal helpers ────────────────────────────────────────────
+    def _build_ngrams(self) -> None:
+        start_letters: CounterType[str] = Counter()
+        bigrams: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
+        trigrams: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
 
-# Frequency of starting letters for words
-_START_LETTERS: CounterType[str] | None = None
+        for word in self.words:
+            w = "".join(c for c in word.lower() if c.isalpha())
+            if not w:
+                continue
+            start_letters[w[0]] += 1
+            for a, b in zip(w, w[1:]):
+                bigrams[a][b] += 1
+            for a, b, c in zip(w, w[1:], w[2:]):
+                trigrams[a + b][c] += 1
 
-# Bigram and trigram counts.  ``_BIGRAMS['h']['e']`` counts how often
-# "he" occurs, while ``_TRIGRAMS['th']['e']`` counts occurrences of "the".
-_BIGRAMS: DefaultDict[str, CounterType[str]] | None = None
-_TRIGRAMS: DefaultDict[str, CounterType[str]] | None = None
+        self.start_letters = start_letters
+        self.bigrams = bigrams
+        self.trigrams = trigrams
+        self.ready = True
 
-_READY = False
-_THREAD: threading.Thread | None = None
-_LOCK = threading.Lock()
+    def _ensure_thread(self) -> None:
+        """Kick off n-gram building in the background if not already running."""
 
+        if self.ready or self.thread is not None:
+            return
+        with self.lock:
+            if self.thread is None and not self.ready:
+                self.thread = threading.Thread(target=self._build_ngrams, daemon=True)
+                self.thread.start()
 
-def _build_ngrams() -> None:
-    start_letters: CounterType[str] = Counter()
-    bigrams: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
-    trigrams: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
+    def _fallback_letters(self, prefix: str, k: int) -> list[str]:
+        cleaned = "".join(c for c in prefix.lower() if c.isalpha())
 
-    for word in _WORDS:
-        w = "".join(c for c in word.lower() if c.isalpha())
-        if not w:
-            continue
-        start_letters[w[0]] += 1
-        for a, b in zip(w, w[1:]):
-            bigrams[a][b] += 1
-        for a, b, c in zip(w, w[1:], w[2:]):
-            trigrams[a + b][c] += 1
-
-    global _START_LETTERS, _BIGRAMS, _TRIGRAMS, _READY
-    _START_LETTERS = start_letters
-    _BIGRAMS = bigrams
-    _TRIGRAMS = trigrams
-    _READY = True
-
-
-def _ensure_thread() -> None:
-    """Kick off n-gram building in the background if not already running."""
-
-    global _THREAD
-    if _READY or _THREAD is not None:
-        return
-    with _LOCK:
-        if _THREAD is None and not _READY:
-            _THREAD = threading.Thread(target=_build_ngrams, daemon=True)
-            _THREAD.start()
-
-
-def _fallback_letters(prefix: str, k: int) -> list[str]:
-    cleaned = "".join(c for c in prefix.lower() if c.isalpha())
-
-    counts = Counter()
-    if not cleaned:
-        counts = _FALLBACK_STARTS
-    else:
-        n = len(cleaned)
-        for w in _WORDS:
-            if w.startswith(cleaned) and len(w) > n:
-                c = w[n]
-                if c.isalpha():
-                    counts[c] += 1
-        if not counts:
-            counts = _FALLBACK_STARTS
-
-    return [c for c, _ in counts.most_common(k)]
-
-
-# ───────── public API ─────────────────────────────────────────────────────
-
-
-@lru_cache(maxsize=2048)
-def suggest_words(prefix: str, k: int = 3) -> list[str]:
-    """Return up to ``k`` common words starting with ``prefix``."""
-    _ensure_thread()
-
-    if not prefix:
-        return []
-    p = prefix.lower()
-    return [w for w in _WORDS if w.startswith(p)][:k]
-
-
-@lru_cache(maxsize=2048)
-def suggest_letters(prefix: str, k: int = 3) -> list[str]:
-    """Suggest up to ``k`` likely next letters for ``prefix``."""
-    _ensure_thread()
-
-    if not _READY:
-        return _fallback_letters(prefix, k)
-
-    cleaned = "".join(c for c in prefix.lower() if c.isalpha())
-    if not cleaned:
-        assert _START_LETTERS is not None
-        source = _START_LETTERS
-    else:
-        last2 = cleaned[-2:]
-        if len(last2) == 2 and _TRIGRAMS is not None and last2 in _TRIGRAMS:
-            source = _TRIGRAMS[last2]
+        counts = Counter()
+        if not cleaned:
+            counts = self.fallback_starts
         else:
-            last1 = cleaned[-1]
-            assert _BIGRAMS is not None and _START_LETTERS is not None
-            source = _BIGRAMS.get(last1, _START_LETTERS)
+            n = len(cleaned)
+            for w in self.words:
+                if w.startswith(cleaned) and len(w) > n:
+                    c = w[n]
+                    if c.isalpha():
+                        counts[c] += 1
+            if not counts:
+                counts = self.fallback_starts
 
-    return [letter for letter, _ in source.most_common(k)]
+        return [c for c, _ in counts.most_common(k)]
 
+    # ───────── public API ─────────────────────────────────────────────────
+    @lru_cache(maxsize=2048)
+    def suggest_words(self, prefix: str, k: int = 3) -> list[str]:
+        """Return up to ``k`` common words starting with ``prefix``."""
+        self._ensure_thread()
+
+        if not prefix:
+            return []
+        p = prefix.lower()
+        return [w for w in self.words if w.startswith(p)][:k]
+
+    @lru_cache(maxsize=2048)
+    def suggest_letters(self, prefix: str, k: int = 3) -> list[str]:
+        """Suggest up to ``k`` likely next letters for ``prefix``."""
+        self._ensure_thread()
+
+        if not self.ready:
+            return self._fallback_letters(prefix, k)
+
+        cleaned = "".join(c for c in prefix.lower() if c.isalpha())
+        if not cleaned:
+            assert self.start_letters is not None
+            source = self.start_letters
+        else:
+            last2 = cleaned[-2:]
+            if len(last2) == 2 and self.trigrams is not None and last2 in self.trigrams:
+                source = self.trigrams[last2]
+            else:
+                last1 = cleaned[-1]
+                assert self.bigrams is not None and self.start_letters is not None
+                source = self.bigrams.get(last1, self.start_letters)
+
+        return [letter for letter, _ in source.most_common(k)]
+
+
+# A module-level predictor for simple use
+default_predictor = Predictor()
+
+
+def suggest_words(prefix: str, k: int = 3) -> list[str]:
+    """Wrapper around :meth:`Predictor.suggest_words` using ``default_predictor``."""
+
+    return default_predictor.suggest_words(prefix, k)
+
+
+def suggest_letters(prefix: str, k: int = 3) -> list[str]:
+    """Wrapper around :meth:`Predictor.suggest_letters` using ``default_predictor``."""
+
+    return default_predictor.suggest_letters(prefix, k)
+
+
+__all__ = [
+    "Predictor",
+    "default_predictor",
+    "suggest_words",
+    "suggest_letters",
+]

--- a/tests/test_predictive.py
+++ b/tests/test_predictive.py
@@ -11,9 +11,9 @@ def test_letter_suggestion():
 
 def test_ngram_thread_starts_on_demand(monkeypatch):
     importlib.reload(predictive)
-    assert predictive._THREAD is None
+    assert predictive.default_predictor.thread is None
 
     letters = predictive.suggest_letters("an")
     assert len(letters) > 0
-    assert predictive._THREAD is not None
+    assert predictive.default_predictor.thread is not None
 


### PR DESCRIPTION
## Summary
- compute fallback ngrams inside `Predictor.__init__`
- drop remaining module-level constants

## Testing
- `pip install wordfreq -q`
- `pip install numpy -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686accef882883339f8c07dd2af601e1