### PR TITLE
Handle multi-dimensional blocks in detect_edges

### DIFF
--- a/switch_interface/detection.py
+++ b/switch_interface/detection.py
@@ -31,7 +31,9 @@ def detect_edges(
     """
 
     if block.ndim != 1:
-        raise ValueError("block must be a 1-D array")
+        raise ValueError(
+            f"block must be a 1-D array (got shape {block.shape})"
+        )
 
     if state.armed:
         # exponential moving average over the current block

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,0 +1,23 @@
+import types
+import sys
+import numpy as np
+import pytest
+
+# Provide a dummy sounddevice module so detection imports succeed
+sd_mod = types.SimpleNamespace(
+    WasapiSettings=lambda exclusive=True: None,
+    query_hostapis=lambda idx: {"name": "Other"},
+    default=types.SimpleNamespace(hostapi=0),
+)
+sys.modules.setdefault("sounddevice", sd_mod)
+
+from switch_interface.detection import detect_edges, EdgeState
+
+
+def test_detect_edges_requires_1d():
+    state = EdgeState(armed=True, cooldown=0)
+    block = np.zeros((2, 2))
+    with pytest.raises(ValueError) as excinfo:
+        detect_edges(block, state, -0.2, -0.5, 1)
+    assert "block must be a 1-D array" in str(excinfo.value)
+    assert "(2, 2)" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- raise informative error in `detect_edges` when passed a multi-D array
- add regression test for invalid block shape

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686adb8e9bb48333bd23e7f765831862