### PR TITLE
Add detector calibration UI

### DIFF
--- a/switch_interface/__main__.py
+++ b/switch_interface/__main__.py
@@ -8,6 +8,7 @@ import threading
 from queue import Empty, SimpleQueue
 
 from .detection import listen
+from .calibration import calibrate, DetectorConfig
 from .kb_gui import VirtualKeyboard
 from .kb_layout_io import load_keyboard
 from .pc_control import PCController
@@ -35,6 +36,11 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Use row/column scanning instead of simple linear scanning",
     )
+    parser.add_argument(
+        "--calibrate",
+        action="store_true",
+        help="Show calibration sliders before launching",
+    )
     args = parser.parse_args(argv)
 
     pc_controller = PCController()
@@ -43,6 +49,8 @@ def main(argv: list[str] | None = None) -> None:
     )
     scanner = Scanner(vk, dwell=args.dwell, row_column_scan=args.row_column)
     scanner.start()
+
+    cfg = calibrate() if args.calibrate else DetectorConfig()
 
     press_queue: SimpleQueue[None] = SimpleQueue()
 
@@ -58,7 +66,18 @@ def main(argv: list[str] | None = None) -> None:
             scanner.on_press()
         vk.root.after(10, _pump_queue)
 
-    threading.Thread(target=listen, args=(_on_switch,), daemon=True).start()
+    threading.Thread(
+        target=listen,
+        args=(_on_switch,),
+        daemon=True,
+        kwargs=dict(
+            upper_offset=cfg.upper_offset,
+            lower_offset=cfg.lower_offset,
+            samplerate=cfg.samplerate,
+            blocksize=cfg.blocksize,
+            debounce_ms=cfg.debounce_ms,
+        ),
+    ).start()
     vk.root.after(10, _pump_queue)
     vk.run()
 

--- a/switch_interface/calibration.py
+++ b/switch_interface/calibration.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+import tkinter as tk
+
+@dataclass
+class DetectorConfig:
+    upper_offset: float = -0.2
+    lower_offset: float = -0.5
+    samplerate: int = 44_100
+    blocksize: int = 256
+    debounce_ms: int = 40
+
+
+def calibrate(config: DetectorConfig | None = None) -> DetectorConfig:
+    """Launch a simple UI to adjust detector settings."""
+    config = config or DetectorConfig()
+    root = tk.Tk()
+    root.title("Calibrate Detector")
+
+    u_var = tk.DoubleVar(value=config.upper_offset)
+    l_var = tk.DoubleVar(value=config.lower_offset)
+    sr_var = tk.IntVar(value=config.samplerate)
+    bs_var = tk.IntVar(value=config.blocksize)
+    db_var = tk.IntVar(value=config.debounce_ms)
+
+    tk.Scale(
+        root,
+        variable=u_var,
+        from_=-1.0,
+        to=0.0,
+        resolution=0.01,
+        label="Upper offset",
+        orient=tk.HORIZONTAL,
+    ).pack(fill=tk.X, padx=10, pady=5)
+
+    tk.Scale(
+        root,
+        variable=l_var,
+        from_=-1.0,
+        to=0.0,
+        resolution=0.01,
+        label="Lower offset",
+        orient=tk.HORIZONTAL,
+    ).pack(fill=tk.X, padx=10, pady=5)
+
+    tk.Scale(
+        root,
+        variable=sr_var,
+        from_=8_000,
+        to=96_000,
+        resolution=1_000,
+        label="Sample rate",
+        orient=tk.HORIZONTAL,
+    ).pack(fill=tk.X, padx=10, pady=5)
+
+    tk.Scale(
+        root,
+        variable=bs_var,
+        from_=64,
+        to=1024,
+        resolution=64,
+        label="Block size",
+        orient=tk.HORIZONTAL,
+    ).pack(fill=tk.X, padx=10, pady=5)
+
+    tk.Scale(
+        root,
+        variable=db_var,
+        from_=5,
+        to=200,
+        resolution=1,
+        label="Debounce ms",
+        orient=tk.HORIZONTAL,
+    ).pack(fill=tk.X, padx=10, pady=5)
+
+    result: DetectorConfig | None = None
+
+    def _start() -> None:
+        nonlocal result
+        result = DetectorConfig(
+            upper_offset=u_var.get(),
+            lower_offset=l_var.get(),
+            samplerate=sr_var.get(),
+            blocksize=bs_var.get(),
+            debounce_ms=db_var.get(),
+        )
+        root.destroy()
+
+    tk.Button(root, text="Start", command=_start).pack(pady=10)
+    root.mainloop()
+
+    assert result is not None
+    return result


### PR DESCRIPTION
## Summary
- add `calibration` module with `DetectorConfig` and `calibrate()`
- expose a `--calibrate` flag in the CLI to adjust detector settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686beb19cdec8333a5dc7ce6587a234b