### PR TITLE
Improve audio stream error handling

### DIFF
--- a/switch_interface/detection.py
+++ b/switch_interface/detection.py
@@ -135,12 +135,19 @@ def listen(
 
     try:
         _run(stream_kwargs)
-    except sd.PortAudioError:
+    except sd.PortAudioError as exc:
         if extra is not None:
             stream_kwargs.pop("extra_settings", None)
-            _run(stream_kwargs)
+            try:
+                _run(stream_kwargs)
+            except sd.PortAudioError as exc2:
+                raise RuntimeError(
+                    "Failed to open audio input device"
+                ) from exc2
         else:
-            raise
+            raise RuntimeError(
+                "Failed to open audio input device"
+            ) from exc
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- raise `RuntimeError` when audio input cannot open
- test that failure after fallback triggers runtime error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bef39c7ec8333bfe40b20cf1bf401