### PR TITLE
Implement persistent calibration settings

### DIFF
--- a/switch_interface/__main__.py
+++ b/switch_interface/__main__.py
@@ -9,7 +9,7 @@ from queue import Empty, SimpleQueue
 
 import json
 from .detection import listen
-from .calibration import calibrate, DetectorConfig
+from .calibration import calibrate, DetectorConfig, load_config, save_config
 from .kb_gui import VirtualKeyboard
 from .kb_layout_io import load_keyboard
 from .pc_control import PCController
@@ -59,7 +59,10 @@ def main(argv: list[str] | None = None) -> None:
     scanner = Scanner(vk, dwell=args.dwell, row_column_scan=args.row_column)
     scanner.start()
 
-    cfg = calibrate() if args.calibrate else DetectorConfig()
+    cfg = load_config()
+    if args.calibrate:
+        cfg = calibrate(cfg)
+        save_config(cfg)
 
     press_queue: SimpleQueue[None] = SimpleQueue()
 

--- a/switch_interface/calibration.py
+++ b/switch_interface/calibration.py
@@ -1,4 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
+import json
+import os
 import tkinter as tk
 
 @dataclass
@@ -8,6 +10,27 @@ class DetectorConfig:
     samplerate: int = 44_100
     blocksize: int = 256
     debounce_ms: int = 40
+
+
+CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".switch_interface")
+CONFIG_FILE = os.path.join(CONFIG_DIR, "detector.json")
+
+
+def load_config(path: str = CONFIG_FILE) -> "DetectorConfig":
+    """Return saved detector settings or defaults if unavailable."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return DetectorConfig(**data)
+    except Exception:
+        return DetectorConfig()
+
+
+def save_config(config: "DetectorConfig", path: str = CONFIG_FILE) -> None:
+    """Persist ``config`` to ``path`` in JSON format."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(asdict(config), f)
 
 
 def calibrate(config: DetectorConfig | None = None) -> DetectorConfig:

--- a/tests/test_calibration_persistence.py
+++ b/tests/test_calibration_persistence.py
@@ -1,0 +1,9 @@
+from switch_interface.calibration import DetectorConfig, save_config, load_config
+
+
+def test_save_and_load(tmp_path):
+    cfg = DetectorConfig(upper_offset=-0.1, lower_offset=-0.6, samplerate=8000, blocksize=128, debounce_ms=50)
+    path = tmp_path / "detector.json"
+    save_config(cfg, path=str(path))
+    loaded = load_config(path=str(path))
+    assert loaded == cfg


### PR DESCRIPTION
## Summary
- persist detector settings to `~/.switch_interface/detector.json`
- load saved settings at startup
- save new settings when `--calibrate` is used
- add regression test for saving/loading configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bfec68d40833397dadac317df4375