### PR TITLE
Set GUI launcher as main entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,25 @@ pip install -e .
 
 ## Usage
 
-Launch the interface with a keyboard layout JSON file:
+Launch the graphical interface:
 
 ```bash
-switch-interface --layout switch_interface/resources/layouts/pred_test.json
+switch-interface
 ```
 
-You can also launch a small graphical window to choose these options interactively:
+Command line usage is still available via:
 
 ```bash
-switch-interface-gui
+switch-interface-cli --layout switch_interface/resources/layouts/pred_test.json
 ```
 
 The CLI also accepts optional flags:
 
 - `--dwell SECONDS` — how long each key remains highlighted (default: 0.6).
 - `--row-column` — use row/column scanning instead of linear scanning.
+
+If no microphone is detected when launching the GUI, an error will direct you to
+the calibration menu where you can choose an input device from a dropdown.
 
 On Windows the microphone is opened in WASAPI exclusive mode when possible. If
 exclusive access fails, the program falls back to the default shared mode.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
 ]
 
 [project.scripts]
-switch-interface = "switch_interface.__main__:main"
-switch-interface-gui = "switch_interface.launcher:main"
+switch-interface = "switch_interface.launcher:main"
+switch-interface-cli = "switch_interface.__main__:main"
 
 [tool.setuptools.package-data]
 switch_interface = ["resources/**/*.json"]

--- a/switch_interface/launcher.py
+++ b/switch_interface/launcher.py
@@ -58,12 +58,20 @@ def main() -> None:
     )
 
     def _start() -> None:
-        root.destroy()
         layout = resources.files(LAYOUT_PACKAGE).joinpath(layout_var.get())
         args = ["--layout", str(layout), "--dwell", str(dwell_var.get())]
         if rowcol_var.get():
             args.append("--row-column")
-        __main__.main(args)
+        try:
+            __main__.main(args)
+        except RuntimeError:
+            tk.messagebox.showerror(
+                "Error",
+                "Could not read switch. Open Calibrate to choose a microphone.",
+                parent=root,
+            )
+            return
+        root.destroy()
 
     tk.Button(root, text="Start", command=_start).pack(side=tk.RIGHT, padx=10, pady=10)
 

--- a/tests/test_calibration_persistence.py
+++ b/tests/test_calibration_persistence.py
@@ -7,7 +7,7 @@ from switch_interface.calibration import DetectorConfig, save_config, load_confi
 
 
 def test_save_and_load(tmp_path):
-    cfg = DetectorConfig(upper_offset=-0.1, lower_offset=-0.6, samplerate=8000, blocksize=128, debounce_ms=50)
+    cfg = DetectorConfig(upper_offset=-0.1, lower_offset=-0.6, samplerate=8000, blocksize=128, debounce_ms=50, device=None)
     path = tmp_path / "detector.json"
     save_config(cfg, path=str(path))
     loaded = load_config(path=str(path))


### PR DESCRIPTION
## Summary
- make the Tk launcher the default executable
- allow choosing an input device in calibration
- detect missing microphones at startup and show an error from the GUI
- keep CLI available as `switch-interface-cli`
- update docs and tests for the new behaviour
- flash calibration window when a switch press is detected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c56ce5d1083338c9db6d184ccde92