### PR TITLE
Fix wasapi module path

### DIFF
--- a/switch_interface.egg-info/SOURCES.txt
+++ b/switch_interface.egg-info/SOURCES.txt
@@ -20,7 +20,10 @@ switch_interface.egg-info/dependency_links.txt
 switch_interface.egg-info/entry_points.txt
 switch_interface.egg-info/requires.txt
 switch_interface.egg-info/top_level.txt
-switch_interface/audio/wasapi.py
+switch_interface/audio/backends/alsa.py
+switch_interface/audio/backends/coreaudio.py
+switch_interface/audio/backends/pulse.py
+switch_interface/audio/backends/wasapi.py
 switch_interface/resources/__init__.py
 switch_interface/resources/layouts/__init__.py
 switch_interface/resources/layouts/alphabet_symbols.json
@@ -34,5 +37,4 @@ tests/test_calibration_ui.py
 tests/test_layout_loader.py
 tests/test_pc_control.py
 tests/test_predictive.py
-tests/test_scan_engine.py
-tests/test_wasapi.py
+tests/test_scan_engine.pytests/test_wasapi.py

--- a/switch_interface/calibration.py
+++ b/switch_interface/calibration.py
@@ -8,7 +8,7 @@ import numpy as np
 import sounddevice as sd
 import math
 
-from .audio.wasapi import get_extra_settings
+from .audio.backends.wasapi import get_extra_settings
 from .detection import detect_edges, EdgeState
 
 @dataclass

--- a/switch_interface/detection.py
+++ b/switch_interface/detection.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import dataclass
 from typing import Callable, Optional, Tuple
 
-from .audio.wasapi import get_extra_settings
+from .audio.backends.wasapi import get_extra_settings
 
 import numpy as np
 

--- a/tests/test_calibration_ui.py
+++ b/tests/test_calibration_ui.py
@@ -122,7 +122,7 @@ def _setup_dummy_sd(monkeypatch):
 def test_calibrate_canvas_and_stream(monkeypatch):
     DummyTk = _setup_dummy_tk(monkeypatch)
     calls = _setup_dummy_sd(monkeypatch)
-    monkeypatch.setattr('switch_interface.audio.wasapi.get_extra_settings', lambda: None)
+    monkeypatch.setattr('switch_interface.audio.backends.wasapi.get_extra_settings', lambda: None)
     import switch_interface.calibration as calibration
     importlib.reload(calibration)
     res = calibration.calibrate(calibration.DetectorConfig())

--- a/tests/test_wasapi.py
+++ b/tests/test_wasapi.py
@@ -6,7 +6,7 @@ import pytest
 
 def _reload_with_dummy_sd(monkeypatch, sd_mod):
     monkeypatch.setitem(sys.modules, "sounddevice", sd_mod)
-    import switch_interface.audio.wasapi as wasapi
+    import switch_interface.audio.backends.wasapi as wasapi
     importlib.reload(wasapi)
     return wasapi
 


### PR DESCRIPTION
## Summary
- import WASAPI backend via `switch_interface.audio.backends`
- update imports for detection and calibration modules
- update test imports
- track new audio backend paths in `SOURCES.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8ccc44d48333bd280046c13c2a45