### PR TITLE
Improve auto calibration edge detection

### DIFF
--- a/switch_interface/auto_calibration.py
+++ b/switch_interface/auto_calibration.py
@@ -33,10 +33,9 @@ def _detect_events(
         if not len(block):
             continue
         dyn_lower = bias + lower
-        if armed:
-            valid = block[block > dyn_lower]
-            if valid.size:
-                bias = 0.995 * bias + 0.005 * float(valid.mean())
+        valid = block[block > dyn_lower]
+        if valid.size:
+            bias = 0.99 * bias + 0.01 * float(valid.mean())
         dyn_upper = bias + upper
         dyn_lower = bias + lower
 

--- a/switch_interface/calibration.py
+++ b/switch_interface/calibration.py
@@ -148,14 +148,16 @@ def calibrate(config: DetectorConfig | None = None) -> DetectorConfig:
             buf[: n - first] = mono[first:]
         buf_index = (buf_index + n) % len(buf)
         refract = int(math.ceil((db_var.get() / 1000) * sr_var.get()))
-        edge_state, pressed = detect_edges(
+        edge_state, idx = detect_edges(
             mono,
             edge_state,
             u_var.get(),
             l_var.get(),
             refract,
+            verbose=False,
+            block_index=0,
         )
-        if pressed:
+        if idx is not None:
             press_pending = True
 
     def _start_stream() -> None:

--- a/tests/test_auto_calibration.py
+++ b/tests/test_auto_calibration.py
@@ -7,6 +7,7 @@ def test_calibrate_fixture():
     cfg = calibrate(data, fs=48_000, target_presses=10)
     assert isinstance(cfg, dict)
     assert set(cfg) == {"upper_offset", "lower_offset", "debounce_ms", "block_size"}
+    assert cfg["upper_offset"] > -0.36
     assert cfg["upper_offset"] > cfg["lower_offset"]
     assert isinstance(cfg["debounce_ms"], int)
     assert isinstance(cfg["block_size"], int)


### PR DESCRIPTION
## Summary
- track bias continuously in detection and calibration logic
- allow mid-block re‑arming of edge detector
- expose verbose tracing in listen/detect_edges
- tighten calibration bounds in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701e68804c83339d5ffe002de9e62e