### PR TITLE
Implement calibration robustness checks

### DIFF
--- a/switch_interface/scripts/check_calibration.py
+++ b/switch_interface/scripts/check_calibration.py
@@ -8,6 +8,8 @@ data = np.load(CLIP)
 cfg  = calibrate(data, fs=FS, verbose=True)   # prints DEBUG info
 gt   = _count_events(data, FS,
                      cfg.upper_offset, cfg.lower_offset, debounce_ms=8)
+from switch_interface.auto_calibration import _has_duplicates
+assert not _has_duplicates(cfg.events, cfg.debounce_ms, FS)
 
 precision = 1.0                                # by design, no false+
 recall    = len(cfg.events) / len(gt)


### PR DESCRIPTION
## Summary
- check for duplicate events with `_has_duplicates`
- try increasing debounce and widen hysteresis in `calibrate`
- assert no duplicates in `check_calibration.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687082163f3c833396582c84209b7fb4