### PR TITLE
Enable match-N press calibration

### DIFF
--- a/switch_interface/scripts/check_calibration.py
+++ b/switch_interface/scripts/check_calibration.py
@@ -5,10 +5,11 @@ CLIP = "calibration_long.npy"
 FS   = 48_000
 
 data = np.load(CLIP)
-cfg  = calibrate(data, fs=FS, verbose=True)   # prints DEBUG info
+cfg  = calibrate(data, fs=FS, target_presses=50, verbose=True)   # prints DEBUG info
 gt   = _count_events(data, FS,
                      cfg.upper_offset, cfg.lower_offset, debounce_ms=8)
 from switch_interface.auto_calibration import _has_duplicates
+assert len(cfg.events) == 50
 assert not _has_duplicates(cfg.events, cfg.debounce_ms, FS)
 
 precision = 1.0                                # by design, no false+

--- a/switch_interface/scripts/live_smoke.py
+++ b/switch_interface/scripts/live_smoke.py
@@ -3,11 +3,12 @@ from switch_interface.auto_calibration import calibrate
 from switch_interface.detection import listen
 
 FS = 48_000
-print("▶  Capturing 10 s live clip for on-the-spot calibration …")
-rec = sd.rec(int(10 * FS), samplerate=FS, channels=1, dtype="float32")
+TARGET = 20
+print(f"▶  Press the switch exactly {TARGET} times …")
+rec = sd.rec(int(8 * FS), samplerate=FS, channels=1, dtype="int16")
 sd.wait()
-clip = rec[:, 0]
-cfg  = calibrate(clip, fs=FS, verbose=True)
+samples = rec[:, 0].astype("float32") / 32768.0
+cfg  = calibrate(samples, fs=FS, target_presses=TARGET, verbose=True)
 
 print("\n▶  Real-time listening (Ctrl-C to stop). Press the switch at will.")
 def on_press():


### PR DESCRIPTION
## Summary
- add optional `target_presses` to auto calibration
- update auto calibration to try matching a fixed press count before recall sweep
- check calibration script uses a known press count
- live smoke test asks for a fixed number of presses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870851206488333ba607d05e85630ba