### PR TITLE
Organize artifacts and centralize logging

### DIFF
--- a/switch_interface/__main__.py
+++ b/switch_interface/__main__.py
@@ -14,10 +14,12 @@ from .kb_gui import VirtualKeyboard
 from .kb_layout_io import load_keyboard
 from .pc_control import PCController
 from .scan_engine import Scanner
+from .logging import setup as setup_logging
 
 
 def main(argv: list[str] | None = None) -> None:
     """Launch the scanning keyboard interface."""
+    setup_logging()
     parser = argparse.ArgumentParser(
         description="Run the switch-accessible virtual keyboard",
     )

--- a/switch_interface/auto_calibration.py
+++ b/switch_interface/auto_calibration.py
@@ -29,12 +29,6 @@ from .detection import EdgeState, detect_edges
 # logging
 # ------------------------------------------------------------------ #
 logger = logging.getLogger("switch.calib")
-if not logger.handlers:
-    h = logging.StreamHandler()
-    h.setFormatter(
-        logging.Formatter("%(asctime)s  %(levelname)-8s  %(message)s", "%H:%M:%S")
-    )
-    logger.addHandler(h)
 logger.setLevel(logging.INFO)  # DEBUG when verbose
 
 

--- a/switch_interface/logging.py
+++ b/switch_interface/logging.py
@@ -1,0 +1,11 @@
+import logging
+
+
+def setup(level: int = logging.INFO) -> None:
+    """Configure basic logging for the package."""
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s  %(levelname)-8s  %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+

--- a/switch_interface/scripts/check_calibration.py
+++ b/switch_interface/scripts/check_calibration.py
@@ -1,10 +1,13 @@
+from pathlib import Path
+
 import numpy as np
 from switch_interface.auto_calibration import calibrate, _count_events
 
-CLIP = "calibration_long.npy"
-FS   = 48_000
+ROOT = Path(__file__).resolve().parents[2]
+CLIP = ROOT / "tests" / "data" / "calibration_long.npy"
+FS = 48_000
 
-data = np.load(CLIP)
+data = np.load(str(CLIP))
 cfg  = calibrate(data, fs=FS, target_presses=50, verbose=True)   # prints DEBUG info
 gt   = _count_events(data, FS,
                      cfg.upper_offset, cfg.lower_offset, debounce_ms=8)


### PR DESCRIPTION
## Summary
- move `calibration_long.npy` into `tests/data`
- use centralized logging setup
- update check calibration script for new data location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b7820d10833389e485c37f82b354