### PR TITLE
Add robust setup wizard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "pynput>=1.8",
   # predictive text
   "wordfreq>=3.1",
+  "appdirs>=1.4",
 ]
 
 # ---------- Optional groups ----------

--- a/switch_interface/config.py
+++ b/switch_interface/config.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from appdirs import user_config_dir
+
+CONFIG_DIR = Path(user_config_dir("switch_interface"))
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
+SCAN_PRESETS = {
+    "slow": 0.7,
+    "medium": 0.45,
+    "fast": 0.25,
+}
+
+
+def exists(path: Path = CONFIG_FILE) -> bool:
+    return Path(path).exists()
+
+
+def load(path: Path = CONFIG_FILE) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save(cfg: dict, path: Path = CONFIG_FILE) -> None:
+    os.makedirs(path.parent, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(cfg, f)
+
+
+def get_scan_interval(preset: str) -> float:
+    return SCAN_PRESETS[preset.lower()]

--- a/switch_interface/gui.py
+++ b/switch_interface/gui.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+import sounddevice as sd
+
+from . import config, calibration
+
+
+class FirstRunWizard(tk.Toplevel):
+    """Guided setup shown on first launch."""
+
+    def __init__(self, master: tk.Misc | None = None):
+        super().__init__(master)
+        self.title("Setup Wizard")
+        self.resizable(False, False)
+        self.protocol("WM_DELETE_WINDOW", self._on_close)
+
+        self.device_var = tk.StringVar(master=self)
+        self.preset_var = tk.StringVar(master=self, value="medium")
+        self.status_var = tk.StringVar(master=self, value="")
+        self.progress = None
+        self.calib_data: dict | None = None
+
+        self.steps = []
+        self._build_steps()
+        self._show_step(0)
+
+        self.transient(master)
+        self.grab_set()
+        self.update_idletasks()
+        root = master if master is not None else self.master
+        self.geometry(
+            f"+{root.winfo_screenwidth()//2 - self.winfo_width()//2}"
+            f"+{root.winfo_screenheight()//3 - self.winfo_height()//2}"
+        )
+
+    # ---------- helpers ----------
+    def _build_steps(self) -> None:
+        self.steps = [
+            self._step_device(),
+            self._step_calibration(),
+            self._step_scan_speed(),
+        ]
+
+    def _show_step(self, idx: int) -> None:
+        for i, frame in enumerate(self.steps):
+            frame.pack_forget()
+            if i == idx:
+                frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+        self.current = idx
+
+    # ---------- step 1 ----------
+    def _step_device(self) -> tk.Frame:
+        frame = tk.Frame(self)
+        tk.Label(frame, text="Select audio device").pack(pady=(0, 5))
+        devices = [
+            (i, d["name"]) for i, d in enumerate(sd.query_devices()) if d.get("max_input_channels", 0) > 0
+        ]
+        if not devices:
+            self.device_var.set("")
+            names = ["None"]
+        else:
+            names = [f"{i}: {n}" for i, n in devices]
+            self.device_var.set(names[0])
+        tk.OptionMenu(frame, self.device_var, *names).pack(fill=tk.X)
+        if not devices:
+            tk.Label(
+                frame,
+                text="No microphone or line-in devices detected. Please connect one and restart.",
+                wraplength=300,
+            ).pack(pady=5)
+            next_state = tk.DISABLED
+        else:
+            next_state = tk.NORMAL
+        tk.Button(frame, text="Next", command=lambda: self._show_step(1), state=next_state).pack(pady=5)
+        if not devices:
+            tk.Button(frame, text="Close", command=self._on_close).pack(pady=5)
+        self._device_map = {name: idx for idx, name in devices}
+        return frame
+
+    # ---------- step 2 ----------
+    def _start_calibration(self) -> None:
+        if self.progress:
+            self.progress.start()
+        self.status_var.set("")
+
+        def worker() -> None:
+            try:
+                device = self._device_map.get(self.device_var.get(), None)
+                self.calib_data = calibration.run_auto_calibration(device)
+                msg = "Calibration successful"
+            except Exception as exc:  # pragma: no cover - unexpected runtime errors
+                self.calib_data = None
+                msg = f"Error: {exc}"
+            self.after(0, lambda: self._finish_calibration(msg))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _finish_calibration(self, msg: str) -> None:
+        if self.progress:
+            self.progress.stop()
+        self.status_var.set(msg)
+        self.next_btn.config(state=tk.NORMAL)
+
+    def _step_calibration(self) -> tk.Frame:
+        frame = tk.Frame(self)
+        tk.Label(frame, text="Auto-calibration").pack(pady=(0, 5))
+        self.progress = ttk.Progressbar(frame, mode="indeterminate")
+        self.progress.pack(fill=tk.X, pady=5)
+        tk.Button(frame, text="Start", command=self._start_calibration).pack()
+        tk.Label(frame, textvariable=self.status_var).pack(pady=5)
+        self.next_btn = tk.Button(frame, text="Next", command=lambda: self._show_step(2), state=tk.DISABLED)
+        self.next_btn.pack(pady=5)
+        return frame
+
+    # ---------- step 3 ----------
+    def _step_scan_speed(self) -> tk.Frame:
+        frame = tk.Frame(self)
+        tk.Label(frame, text="Scanning speed").pack(pady=(0, 5))
+        opts = [
+            ("Slow (700 ms)", "slow"),
+            ("Medium (450 ms)", "medium"),
+            ("Fast (250 ms)", "fast"),
+        ]
+        for lbl, val in opts:
+            tk.Radiobutton(frame, text=lbl, value=val, variable=self.preset_var).pack(anchor=tk.W)
+        tk.Button(frame, text="Finish", command=self._finish).pack(pady=5)
+        return frame
+
+    # ---------- finish ----------
+    def _finish(self) -> None:
+        device = self._device_map.get(self.device_var.get(), None)
+        cfg = {
+            "device": device,
+            "scan_interval": config.get_scan_interval(self.preset_var.get()),
+            "calibration": self.calib_data,
+        }
+        try:
+            config.save(cfg)
+            if self.calib_data is not None:
+                calib_cfg = calibration.DetectorConfig(
+                    upper_offset=self.calib_data["upper_offset"],
+                    lower_offset=self.calib_data["lower_offset"],
+                    samplerate=self.calib_data["samplerate"],
+                    blocksize=self.calib_data["blocksize"],
+                    debounce_ms=self.calib_data["debounce_ms"],
+                    device=device,
+                )
+                calibration.save_config(calib_cfg)
+        except Exception as exc:  # pragma: no cover - filesystem errors
+            messagebox.showerror("Error", str(exc), parent=self)
+        self.grab_release()
+        self.destroy()
+
+    def _on_close(self) -> None:
+        self.grab_release()
+        self.destroy()

--- a/switch_interface/main.py
+++ b/switch_interface/main.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import tkinter as tk
+
+from . import __main__, config
+from .gui import FirstRunWizard
+
+
+def main() -> None:
+    if not config.exists():
+        root = tk.Tk()
+        root.withdraw()
+        wiz = FirstRunWizard(master=root)
+        root.wait_window(wiz)
+        root.destroy()
+    cfg = config.load()
+    dwell = cfg.get("scan_interval", 0.45)
+    __main__.main(["--dwell", str(dwell)])
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    main()


### PR DESCRIPTION
## Summary
- center first-run wizard on screen and make it modal
- warn when no audio devices are present
- persist calibration to `calibration.json`
- use appdirs for cross-platform config directory
- expose `appdirs` in requirements
- remove redundant requirements file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872d00a75d083338ab9fb7ff2cf1dbb