### PR TITLE
Add Windows installer build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 
 # Packaging/build artifacts
 build/
+!build/build_installer.py
+!build/inno_template.iss
 dist/
 *.egg-info/
 

--- a/build/build_installer.py
+++ b/build/build_installer.py
@@ -1,0 +1,80 @@
+import os
+import subprocess
+import sys
+import textwrap
+import venv
+from pathlib import Path
+
+INNO_TEMPLATE = textwrap.dedent(r"""
+[Setup]
+AppName=SwitchInterface
+AppVersion={version}
+AppPublisher=Open-Source AT
+DefaultDirName={{localappdata}}\SwitchInterface
+OutputBaseFilename=SwitchInterface-{version}
+PrivilegesRequired=lowest
+DefaultGroupName=SwitchInterface
+
+[Files]
+Source: "{exe}"; DestDir: "{{app}}"; Flags: ignoreversion
+
+[Icons]
+Name: "{{commondesktop}}\SwitchInterface"; Filename: "{{app}}\SwitchInterface.exe"
+Name: "{{group}}\SwitchInterface"; Filename: "{{app}}\SwitchInterface.exe"
+""")
+
+def run(cmd):
+    print("+", " ".join(map(str, cmd)))
+    subprocess.check_call(cmd)
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    build_dir = repo_root / "build"
+    venv_dir = build_dir / "venv"
+    if not venv_dir.exists():
+        venv.create(venv_dir, with_pip=True)
+    py = venv_dir / ("Scripts" if os.name == "nt" else "bin") / "python"
+
+    run([py, "-m", "pip", "install", "pyinstaller==6.*"])
+
+    exe_name = "SwitchInterface"
+    icon = repo_root / "assets" / "app.ico"
+    run([
+        py,
+        "-m",
+        "PyInstaller",
+        "--noconfirm",
+        "--onefile",
+        "--name",
+        exe_name,
+        f"--icon={icon}",
+        str(repo_root / "switch_interface" / "__main__.py"),
+    ])
+
+    exe_path = repo_root / "dist" / f"{exe_name}.exe"
+    cert_pfx = build_dir / "cert.pfx"
+    run([
+        "signtool",
+        "sign",
+        "/f",
+        str(cert_pfx),
+        "/p",
+        os.environ.get("SIGN_PFX_PASS", ""),
+        str(exe_path),
+    ])
+
+    ns = {}
+    with open(repo_root / "switch_interface" / "__init__.py", "r", encoding="utf-8") as f:
+        exec(f.read(), ns)
+    version = ns.get("__version__")
+    if not version:
+        raise RuntimeError("Version not found")
+
+    iss_content = INNO_TEMPLATE.format(version=version, exe=exe_path)
+    iss_path = build_dir / "installer.iss"
+    iss_path.write_text(iss_content, encoding="utf-8")
+
+    run(["iscc", str(iss_path)])
+
+if __name__ == "__main__":
+    main()

--- a/build/inno_template.iss
+++ b/build/inno_template.iss
@@ -1,0 +1,15 @@
+[Setup]
+AppName=SwitchInterface
+AppVersion={version}
+AppPublisher=Open-Source AT
+DefaultDirName={localappdata}\SwitchInterface
+OutputBaseFilename=SwitchInterface-{version}
+PrivilegesRequired=lowest
+DefaultGroupName=SwitchInterface
+
+[Files]
+Source: "{exe}"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{commondesktop}\SwitchInterface"; Filename: "{app}\SwitchInterface.exe"
+Name: "{group}\SwitchInterface"; Filename: "{app}\SwitchInterface.exe"

--- a/switch_interface/app.py
+++ b/switch_interface/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import tkinter as tk
+
+from . import __main__, config
+from .gui import FirstRunWizard
+
+
+def main() -> None:
+    settings = config.load_settings()
+    root = tk.Tk()
+    root.withdraw()
+    if os.getenv("SKIP_FIRST_RUN") != "1":
+        if settings.get("calibration_complete") is False:
+            FirstRunWizard(root).show_modal()
+            settings = config.load_settings()
+    root.destroy()
+    dwell = settings.get("scan_interval", 0.45)
+    __main__.main(["--dwell", str(dwell)])
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    main()

--- a/switch_interface/config.py
+++ b/switch_interface/config.py
@@ -28,10 +28,20 @@ def load(path: Path = CONFIG_FILE) -> dict:
         return {}
 
 
+def load_settings(path: Path = CONFIG_FILE) -> dict:
+    """Backward-compatible wrapper for :func:`load`."""
+    return load(path)
+
+
 def save(cfg: dict, path: Path = CONFIG_FILE) -> None:
     os.makedirs(path.parent, exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         json.dump(cfg, f)
+
+
+def save_settings(cfg: dict, path: Path = CONFIG_FILE) -> None:
+    """Backward-compatible wrapper for :func:`save`."""
+    save(cfg, path)
 
 
 def get_scan_interval(preset: str) -> float:

--- a/switch_interface/gui.py
+++ b/switch_interface/gui.py
@@ -40,6 +40,10 @@ class FirstRunWizard(tk.Toplevel):
             f"+{root.winfo_screenheight()//3 - self.winfo_height()//2}"
         )
 
+    def show_modal(self) -> None:
+        """Block until the wizard window is closed."""
+        self.wait_window(self)
+
     # ---------- helpers ----------
     def _build_steps(self) -> None:
         self.steps = [
@@ -141,9 +145,10 @@ class FirstRunWizard(tk.Toplevel):
             "device": device,
             "scan_interval": config.get_scan_interval(self.preset_var.get()),
             "calibration": self.calib_data,
+            "calibration_complete": True,
         }
         try:
-            config.save(cfg)
+            config.save_settings(cfg)
             if self.calib_data is not None:
                 calib_cfg = calibration.DetectorConfig(
                     upper_offset=self.calib_data["upper_offset"],


### PR DESCRIPTION
## Summary
- allow committing build scripts in gitignore
- add `build_installer.py` script for building and signing Windows executables
- provide `inno_template.iss` example
- launch the setup wizard automatically when calibration is incomplete

## Testing
- `pip install -e .`
- `pip install -r dev-requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68730c66ccf083338ad6e0e93fb61fe8