### PR TITLE
Refactor detection/listener coupling

### DIFF
--- a/switch_interface/compat.py
+++ b/switch_interface/compat.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import warnings
+
+__all__ = ["check_device", "listen"]
+
+
+def check_device(*args, **kwargs):
+    """Deprecated wrapper for :func:`listener.check_device`."""
+    warnings.warn(
+        "check_device moved to switch_interface.listener",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from .listener import check_device as _real
+
+    return _real(*args, **kwargs)
+
+
+def listen(*args, **kwargs):
+    """Deprecated wrapper for :func:`listener.listen`."""
+    warnings.warn(
+        "listen moved to switch_interface.listener",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from .listener import listen as _real
+
+    return _real(*args, **kwargs)
+

--- a/switch_interface/detection.py
+++ b/switch_interface/detection.py
@@ -116,8 +116,10 @@ if __name__ == "__main__":
         presscount += 1
         print(f"{ts}  PRESS. (count: {presscount})")
 
+    from . import compat
+
     print("Listening…  (Ctrl‑C to stop)")
-    listen(
+    compat.listen(
         _on_press,
         upper_offset=upper_offset,
         lower_offset=lower_offset,

--- a/switch_interface/detection.py
+++ b/switch_interface/detection.py
@@ -11,33 +11,7 @@ from typing import Tuple
 
 import numpy as np
 
-# Lightweight shims to keep the old API stable
-import warnings
-
-def check_device(*args, **kwargs):
-    """Deprecated wrapper of :func:`listener.check_device`."""
-    warnings.warn(
-        "check_device moved to switch_interface.listener",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    from .listener import check_device as _real
-
-    return _real(*args, **kwargs)
-
-
-def listen(*args, **kwargs):
-    """Deprecated wrapper of :func:`listener.listen`."""
-    warnings.warn(
-        "listen moved to switch_interface.listener",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    from .listener import listen as _real
-
-    return _real(*args, **kwargs)
-
-__all__ = ["EdgeState", "detect_edges", "check_device", "listen"]
+__all__ = ["EdgeState", "detect_edges"]
 
 @dataclass
 class EdgeState:
@@ -111,6 +85,14 @@ def detect_edges(
         ),
         press_index is not None,
     )
+
+
+def __getattr__(name: str):
+    if name in {"listen", "check_device"}:
+        from . import compat
+
+        return getattr(compat, name)
+    raise AttributeError(name)
 
 
 


### PR DESCRIPTION
## Summary
- decouple edge-detection module from audio listener
- forward deprecated APIs through new `compat` module

## Testing
- `pytest -q`
- `python -m pipdeptree -w fail`

------
https://chatgpt.com/codex/tasks/task_e_6873cfd820348333a07c1ce085a42c79