### PR TITLE
Improve predictive startup performance and robust layout loading

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=2.0
 pynput>=1.8
 wordfreq>=3.1
 appdirs>=1.4
+jsonschema>=4.24

--- a/switch_interface/kb_layout_io.py
+++ b/switch_interface/kb_layout_io.py
@@ -1,9 +1,51 @@
 import json
 from importlib import resources
 
+from jsonschema import ValidationError, validate
+
 from .kb_layout import Key, Keyboard, KeyboardPage, KeyboardRow
 
 DEFAULT_LAYOUT = "pred_test.json"
+
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "pages": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "rows": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "keys": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {"type": "object", "required": ["label"]},
+                                }
+                            },
+                            "required": ["keys"],
+                        },
+                    }
+                },
+                "required": ["rows"],
+            },
+        }
+    },
+    "required": ["pages"],
+}
+
+
+def _validate_layout(data: dict) -> None:
+    try:
+        validate(data, _SCHEMA)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid keyboard layout: {exc.message}") from None
 
 
 def load_keyboard(path: str | None = None) -> Keyboard:
@@ -19,26 +61,31 @@ def load_keyboard(path: str | None = None) -> Keyboard:
         ):
             blueprint = json.load(file)
 
+    _validate_layout(blueprint)
+
     page_objects = []
-    for page in blueprint["pages"]:
-        row_objects = []
-        for row in page["rows"]:
-            key_objects = []
-            for key in row["keys"]:
-                key_objects.append(
-                    Key(
-                        key["label"],
-                        key.get("action"),
-                        key.get("mode", "tap"),
-                        key.get("dwell") or key.get("dwell_mult"),
+    try:
+        for page in blueprint["pages"]:
+            row_objects = []
+            for row in page["rows"]:
+                key_objects = []
+                for key in row["keys"]:
+                    key_objects.append(
+                        Key(
+                            key["label"],
+                            key.get("action"),
+                            key.get("mode", "tap"),
+                            key.get("dwell") or key.get("dwell_mult"),
+                        )
+                    )
+                row_objects.append(
+                    KeyboardRow(
+                        key_objects,
+                        stretch=row.get("stretch", True),
                     )
                 )
-            row_objects.append(
-                KeyboardRow(
-                    key_objects,
-                    stretch=row.get("stretch", True),
-                )
-            )
-        page_objects.append(KeyboardPage(row_objects))
+            page_objects.append(KeyboardPage(row_objects))
+    except (KeyError, TypeError) as exc:
+        raise ValueError(f"Malformed keyboard layout: {exc}") from None
 
     return Keyboard(page_objects)

--- a/switch_interface/predictive.py
+++ b/switch_interface/predictive.py
@@ -23,8 +23,19 @@ class Predictor:
         self.ready = False
         self.thread: threading.Thread | None = None
         self.lock = threading.Lock()
+        self._prefix_index: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
+        self._build_prefix_index()
 
     # ───────── internal helpers ────────────────────────────────────────────
+    def _build_prefix_index(self) -> None:
+        """Index word prefixes up to length 6 for fast fallback lookups."""
+        for word in self.words:
+            w = "".join(c for c in word.lower() if c.isalpha())
+            for i in range(min(len(w) - 1, 6)):
+                prefix = w[: i + 1]
+                next_letter = w[i + 1]
+                self._prefix_index[prefix][next_letter] += 1
+
     def _build_ngrams(self) -> None:
         start_letters: CounterType[str] = Counter()
         bigrams: DefaultDict[str, CounterType[str]] = defaultdict(Counter)
@@ -57,19 +68,19 @@ class Predictor:
 
     def _fallback_letters(self, prefix: str, k: int) -> list[str]:
         cleaned = "".join(c for c in prefix.lower() if c.isalpha())
-
-        counts: Counter[str] = Counter()
         if not cleaned:
             counts = self.fallback_starts
         else:
-            n = len(cleaned)
-            for w in self.words:
-                if w.startswith(cleaned) and len(w) > n:
-                    c = w[n]
-                    if c.isalpha():
-                        counts[c] += 1
-            if not counts:
-                counts = self.fallback_starts
+            counts = self._prefix_index.get(cleaned)
+            if counts is None or not counts:
+                n = len(cleaned)
+                temp: Counter[str] = Counter()
+                for w in self.words:
+                    if w.startswith(cleaned) and len(w) > n:
+                        c = w[n]
+                        if c.isalpha():
+                            temp[c] += 1
+                counts = temp if temp else self.fallback_starts
 
         return [c for c, _ in counts.most_common(k)]
 

--- a/switch_interface/predictive.py
+++ b/switch_interface/predictive.py
@@ -71,8 +71,10 @@ class Predictor:
         if not cleaned:
             counts = self.fallback_starts
         else:
-            counts = self._prefix_index.get(cleaned)
-            if counts is None or not counts:
+            prefix_counts = self._prefix_index.get(cleaned)
+            if prefix_counts and len(prefix_counts) > 0:
+                counts = prefix_counts
+            else:
                 n = len(cleaned)
                 temp: Counter[str] = Counter()
                 for w in self.words:

--- a/tests/test_layout_loader.py
+++ b/tests/test_layout_loader.py
@@ -1,6 +1,29 @@
+import json
+from importlib import resources
+
+import pytest
+
 from switch_interface.kb_layout_io import load_keyboard
 
 
 def test_default_load():
     kb = load_keyboard()
+    assert len(kb) > 0
+
+
+def test_load_keyboard_missing_fields(tmp_path):
+    bad_layout = {"pages": [{"rows": [{}]}]}
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps(bad_layout))
+    with pytest.raises(ValueError) as exc:
+        load_keyboard(str(p))
+    assert "keys" in str(exc.value)
+
+
+def test_load_keyboard_valid_path():
+    path = (
+        resources.files("switch_interface.resources.layouts")
+        .joinpath("pred_test.json")
+    )
+    kb = load_keyboard(str(path))
     assert len(kb) > 0

--- a/tests/test_predictive.py
+++ b/tests/test_predictive.py
@@ -1,4 +1,6 @@
 import importlib
+import time
+from collections import Counter
 
 import switch_interface.predictive as predictive
 
@@ -17,3 +19,31 @@ def test_ngram_thread_starts_on_demand(monkeypatch):
     letters = predictive.suggest_letters("an")
     assert len(letters) > 0
     assert predictive.default_predictor.thread is not None
+
+
+def _naive_fallback(prefix: str, k: int, words: list[str]) -> list[str]:
+    cleaned = "".join(c for c in prefix.lower() if c.isalpha())
+    counts = Counter()
+    if not cleaned:
+        counts = Counter(w[0] for w in words if w and w[0].isalpha())
+    else:
+        n = len(cleaned)
+        for w in words:
+            if w.startswith(cleaned) and len(w) > n:
+                c = w[n]
+                if c.isalpha():
+                    counts[c] += 1
+        if not counts:
+            counts = Counter(w[0] for w in words if w and w[0].isalpha())
+    return [c for c, _ in counts.most_common(k)]
+
+
+def test_fallback_speed_and_correctness():
+    predictor = predictive.Predictor()
+    prefix = "pre"
+    start = time.perf_counter()
+    result = predictor._fallback_letters(prefix, 3)
+    elapsed = time.perf_counter() - start
+    expected = _naive_fallback(prefix, 3, predictor.words)
+    assert result == expected
+    assert elapsed < 0.005


### PR DESCRIPTION
## Summary
- speed up early predictive typing by indexing prefixes
- validate keyboard layouts with jsonschema and raise friendly errors
- test fallback letter suggestions for speed and accuracy
- test layout loader error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873db0a03288333bf922769b480d9ab