### PR TITLE
Fix CI dependencies, clarify setup, add PulseAudio stub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
-      - name: Install dependencies
-        run: pip install -r dev-requirements.txt -r requirements.txt
+      - name: Install runtime dependencies
+        run: pip install -r requirements.txt
+      - name: Install development dependencies
+        run: pip install -r dev-requirements.txt
       - name: Ruff
         run: ruff check . --output-format=github
       - name: Mypy

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -1,0 +1,5 @@
+# Environment Notes
+
+- **Windows exclusive mode**: On Windows the microphone is opened in WASAPI exclusive mode when possible. If exclusive access fails, the program automatically falls back to the default shared mode.
+- **Log file location**: All console output is mirrored to `~/.switch_interface.log` by default. Pass a custom path to `switch_interface.logging.setup` to store logs elsewhere.
+- **No microphone detected**: If no input device is available, the GUI opens the calibration menu so you can select a device from a drop-down list.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 James Blick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,22 @@ Switch Interface is a lightweight and simple scanning keyboard for one-switch in
 ## Requirements
 
 - Python 3.11 or newer
-- Runtime dependencies are installed automatically via `pip install -e .`.
+
+## Setup
+
+Install runtime dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+For development (tests and linting) install the additional tools:
+
+```bash
+pip install -r dev-requirements.txt
+```
+
+The CI workflow performs the same two commands before running `ruff`, `mypy`, and `pytest`.
 
 ## Getting Started
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description     = "Switch-accessible on-screen keyboard with audio-based single-
 readme          = "README.md"
 requires-python = ">=3.11"
 license         = {text = "MIT"}
-authors         = [{name = "Your Name", email = "you@example.com"}]
+authors         = [{name = "James Blick", email = "jblick1327@gmail.com"}]
 keywords        = ["assistive-technology", "switch-access", "scanning", "AAC"]
 
 # ---------- Runtime dependencies ----------

--- a/switch_interface/__main__.py
+++ b/switch_interface/__main__.py
@@ -15,13 +15,6 @@ import threading
 from pathlib import Path
 from queue import Empty, SimpleQueue
 
-from .calibration import DetectorConfig, calibrate, load_config, save_config
-from .detection import check_device, listen
-from .kb_gui import VirtualKeyboard
-from .kb_layout_io import load_keyboard
-from .pc_control import PCController
-from .scan_engine import Scanner
-
 _LOG_PATH = Path.home() / ".switch_interface.log"
 
 
@@ -61,7 +54,15 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Show calibration sliders before launching",
     )
+
     args = parser.parse_args(argv)
+
+    from .calibration import calibrate, load_config, save_config
+    from .detection import check_device, listen
+    from .kb_gui import VirtualKeyboard
+    from .kb_layout_io import load_keyboard
+    from .pc_control import PCController
+    from .scan_engine import Scanner
 
     cfg = load_config()
     if args.calibrate:

--- a/switch_interface/audio/backends/pulse.py
+++ b/switch_interface/audio/backends/pulse.py
@@ -1,0 +1,13 @@
+"""PulseAudio backend stub.
+
+This module is a placeholder used on platforms without a functional
+PulseAudio implementation. Importing it provides a :class:`PulseAudioBackend`
+class whose constructor immediately raises :class:`NotImplementedError`.
+"""
+
+
+class PulseAudioBackend:
+    """Stubbed backend for the PulseAudio host API."""
+
+    def __init__(self) -> None:
+        raise NotImplementedError("PulseAudio backend not implemented on this platform")

--- a/switch_interface/kb_gui.py
+++ b/switch_interface/kb_gui.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import font, ttk
 from types import SimpleNamespace
 from typing import Callable
+import logging
 
 from . import config
 from .kb_layout import Key, Keyboard
@@ -52,9 +53,9 @@ class VirtualKeyboard:
             self.root.attributes("-alpha", 0.93)
             atop = bool(self.cfg.get("always_on_top", False))
             self.root.attributes("-topmost", atop)
-        except tk.TclError:
+        except tk.TclError as e:
             # Attributes may fail on some platforms (e.g. dummy Tk during tests).
-            pass
+            logging.warning("VirtualKeyboard feature unavailable: %s", e)
 
         # menu with Always on Top option
         menubar = tk.Menu(self.root)
@@ -80,9 +81,9 @@ class VirtualKeyboard:
 
         try:
             ttk.Sizegrip(button_frame).pack(side=tk.RIGHT, padx=(0, 5))
-        except Exception:
+        except Exception as e:
             # Sizegrip may not be available or may fail under headless tests.
-            pass
+            logging.warning("VirtualKeyboard feature unavailable: %s", e)
 
         self.font = font.nametofont("TkDefaultFont").copy()
         self.render_page()
@@ -245,8 +246,8 @@ class VirtualKeyboard:
         flag = bool(self.always_var.get())
         try:
             self.root.attributes("-topmost", flag)
-        except tk.TclError:
-            pass
+        except tk.TclError as e:
+            logging.warning("VirtualKeyboard feature unavailable: %s", e)
         self.cfg["always_on_top"] = flag
         config.save(self.cfg)
 

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -1,0 +1,12 @@
+import subprocess
+import sys
+
+
+def test_cli_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "switch_interface", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "switch-accessible virtual keyboard" in result.stdout


### PR DESCRIPTION
## Summary
- ensure CI installs both runtime and dev dependencies
- document setup steps for local and CI environments
- implement stub for PulseAudio backend
- warn users when optional GUI features fail
- document environment-specific behavior
- add CLI entry-point tests
- add MIT license and update author metadata

## Testing
- `ruff check . --output-format=github`
- `mypy switch_interface`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f37c9bb0833390e6c573efa114d3