### PR TITLE
Fix Windows CLI hang by lazy-loading predictor

### DIFF
--- a/switch_interface/kb_gui.py
+++ b/switch_interface/kb_gui.py
@@ -8,7 +8,11 @@ from . import config
 from .kb_layout import Key, Keyboard
 from .key_types import Action
 from .modifier_state import ModifierState
-from .predictive import Predictor, default_predictor
+from typing import TYPE_CHECKING
+from . import predictive
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .predictive import Predictor
 
 
 class VirtualKeyboard:
@@ -19,12 +23,15 @@ class VirtualKeyboard:
         keyboard: Keyboard,
         on_key: Callable,
         state: ModifierState,
-        predictor: Predictor | None = None,
+        predictor: "Predictor" | None = None,
     ):
         self.keyboard = keyboard
         self.on_key = on_key
         self.state = state
-        self.predictor = predictor or default_predictor
+        if predictor is None:
+            self.predictor = predictive.default_predictor
+        else:
+            self.predictor = predictor
 
         self.current_page = 0
         self.highlight_index = 0

--- a/switch_interface/predictive.py
+++ b/switch_interface/predictive.py
@@ -125,20 +125,32 @@ class Predictor:
         return [letter for letter, _ in source.most_common(k)]
 
 
-# A module-level predictor for simple use
-default_predictor = Predictor()
+_default_predictor: Predictor | None = None
+
+
+def _get_default_predictor() -> Predictor:
+    global _default_predictor
+    if _default_predictor is None:
+        _default_predictor = Predictor()
+    return _default_predictor
 
 
 def suggest_words(prefix: str, k: int = 3) -> list[str]:
     """Wrapper around :meth:`Predictor.suggest_words` using ``default_predictor``."""
 
-    return default_predictor.suggest_words(prefix, k)
+    return _get_default_predictor().suggest_words(prefix, k)
 
 
 def suggest_letters(prefix: str, k: int = 3) -> list[str]:
     """Wrapper around :meth:`Predictor.suggest_letters` using ``default_predictor``."""
 
-    return default_predictor.suggest_letters(prefix, k)
+    return _get_default_predictor().suggest_letters(prefix, k)
+
+
+def __getattr__(name: str):
+    if name == "default_predictor":
+        return _get_default_predictor()
+    raise AttributeError(name)
 
 
 __all__ = [

--- a/switch_interface/predictive.py
+++ b/switch_interface/predictive.py
@@ -9,6 +9,7 @@ from typing import Counter as CounterType
 from typing import DefaultDict
 
 from wordfreq import top_n_list
+from typing import TYPE_CHECKING
 
 
 class Predictor:
@@ -151,6 +152,10 @@ def __getattr__(name: str):
     if name == "default_predictor":
         return _get_default_predictor()
     raise AttributeError(name)
+
+
+if TYPE_CHECKING:  # pragma: no cover - exported via __getattr__
+    default_predictor: Predictor
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- lazily initialize predictive text engine
- import predictive module lazily from kb_gui

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874054e78748333822da70b853bf649