### PR TITLE
Fix compat listen signature

### DIFF
--- a/switch_interface/__main__.py
+++ b/switch_interface/__main__.py
@@ -59,7 +59,8 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     from .calibration import calibrate, load_config, save_config
-    from .detection import check_device, listen
+    from .listener import check_device
+    from .detection import listen
     from .kb_gui import VirtualKeyboard
     from .kb_layout_io import load_keyboard
     from .pc_control import PCController

--- a/switch_interface/compat.py
+++ b/switch_interface/compat.py
@@ -49,6 +49,6 @@ def listen(
             params = {k: config.get(k) for k in attrs}
         else:
             params = {k: getattr(config, k, None) for k in attrs}
-        return _real(on_press, **params)
+        return _real(on_press, **params)  # type: ignore[arg-type]
 
     return _real(on_press, **kwargs)

--- a/switch_interface/compat.py
+++ b/switch_interface/compat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from typing import Any, Callable
 
 __all__ = ["check_device", "listen"]
 
@@ -17,8 +18,17 @@ def check_device(*args, **kwargs):
     return _real(*args, **kwargs)
 
 
-def listen(*args, **kwargs):
-    """Deprecated wrapper for :func:`listener.listen`."""
+def listen(
+    on_press: Callable[[], None],
+    config: Any | None = None,
+    /,
+    **kwargs: Any,
+) -> None:
+    """Deprecated wrapper for :func:`listener.listen`.
+
+    Supports the legacy call signature ``listen(on_press, config)`` where
+    ``config`` provides detector parameters as attributes or mapping keys.
+    """
     warnings.warn(
         "listen moved to switch_interface.listener",
         DeprecationWarning,
@@ -26,5 +36,19 @@ def listen(*args, **kwargs):
     )
     from .listener import listen as _real
 
-    return _real(*args, **kwargs)
+    if config is not None and not kwargs:
+        attrs = [
+            "upper_offset",
+            "lower_offset",
+            "samplerate",
+            "blocksize",
+            "debounce_ms",
+            "device",
+        ]
+        if isinstance(config, dict):
+            params = {k: config.get(k) for k in attrs}
+        else:
+            params = {k: getattr(config, k, None) for k in attrs}
+        return _real(on_press, **params)
 
+    return _real(on_press, **kwargs)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,28 @@
+from switch_interface.compat import listen
+from switch_interface.calibration import DetectorConfig
+
+
+def test_legacy_listen_config(monkeypatch):
+    captured = {}
+
+    def dummy_listen(on_press, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("switch_interface.listener.listen", dummy_listen)
+    cfg = DetectorConfig(
+        upper_offset=-0.3,
+        lower_offset=-0.7,
+        samplerate=12,
+        blocksize=5,
+        debounce_ms=77,
+        device="mic",
+    )
+    listen(lambda: None, cfg)
+    assert captured == {
+        "upper_offset": -0.3,
+        "lower_offset": -0.7,
+        "samplerate": 12,
+        "blocksize": 5,
+        "debounce_ms": 77,
+        "device": "mic",
+    }

--- a/tests/test_main_async.py
+++ b/tests/test_main_async.py
@@ -46,7 +46,7 @@ def test_launch_continues_when_device_check_hangs(monkeypatch, caplog):
     monkeypatch.setattr("switch_interface.kb_layout_io.load_keyboard", lambda p: "kb")
     monkeypatch.setattr("switch_interface.detection.listen", lambda *a, **k: None)
     monkeypatch.setattr(
-        "switch_interface.detection.check_device", lambda *a, **k: time.sleep(5)
+        "switch_interface.listener.check_device", lambda *a, **k: time.sleep(5)
     )
 
     calib_mod = types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- match the legacy `listen()` signature in `compat.py`
- import `check_device` from `listener` in the CLI
- adjust async main test for new import
- add regression test for calling `compat.listen` with a config object

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687420bbc2008333b339277085c3da19