### PR TITLE
Switch launcher as default entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ dev = [
 
 # ---------- Console & GUI entry points ----------
 [project.scripts]
-switch-interface = "switch_interface.__main__:main"
-switch-interface-cli = "switch_interface.__main__:main"
+switch-interface = "switch_interface.launcher:main"
+switch-interface-cli = "switch_interface.__main__:keyboard_main"
 
 # ---------- Pytest config (keeps repo root clean) ----------
 [tool.pytest.ini_options]

--- a/switch_interface/__main__.py
+++ b/switch_interface/__main__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from switch_interface.logging import setup as _setup_logging
+from . import launcher
 
 _setup_logging()
 
@@ -29,7 +30,7 @@ def _open_log_if_exists() -> None:
             subprocess.run(["xdg-open", _LOG_PATH])
 
 
-def main(argv: list[str] | None = None) -> None:
+def keyboard_main(argv: list[str] | None = None) -> None:
     """Launch the scanning keyboard interface."""
     parser = argparse.ArgumentParser(
         description="Run the switch-accessible virtual keyboard",
@@ -129,6 +130,11 @@ def main(argv: list[str] | None = None) -> None:
     ).start()
     vk.root.after(10, _pump_queue)
     vk.run()
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Launch the GUI launcher."""
+    launcher.main()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual entry point

--- a/switch_interface/app.py
+++ b/switch_interface/app.py
@@ -17,7 +17,7 @@ def main() -> None:
             settings = config.load_settings()
     root.destroy()
     dwell = settings.get("scan_interval", 0.45)
-    __main__.main(["--dwell", str(dwell)])
+    __main__.keyboard_main(["--dwell", str(dwell)])
 
 
 if __name__ == "__main__":  # pragma: no cover - manual launch

--- a/switch_interface/launcher.py
+++ b/switch_interface/launcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import tkinter as tk
 from importlib import resources
 from pathlib import Path
@@ -22,6 +23,10 @@ def list_layouts() -> list[Path]:
 
 
 def main() -> None:
+    if os.getenv("SI_TEST_MODE") == "1":
+        print("launcher-main-invoked")
+        return
+
     root = tk.Tk()
     root.title("Launch Switch Interface")
 
@@ -62,7 +67,7 @@ def main() -> None:
         if rowcol_var.get():
             args.append("--row-column")
         try:
-            __main__.main(args)
+            __main__.keyboard_main(args)
         except RuntimeError:
             tk.messagebox.showerror(
                 "Error",

--- a/switch_interface/main.py
+++ b/switch_interface/main.py
@@ -15,7 +15,7 @@ def main() -> None:
         root.destroy()
     cfg = config.load()
     dwell = cfg.get("scan_interval", 0.45)
-    __main__.main(["--dwell", str(dwell)])
+    __main__.keyboard_main(["--dwell", str(dwell)])
 
 
 if __name__ == "__main__":  # pragma: no cover - manual launch

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import sys
-from pathlib import Path
+from importlib import metadata
 
 
 def test_module_uses_launcher():
@@ -21,12 +21,15 @@ def test_module_uses_launcher():
 
 
 def test_console_script_uses_launcher():
-    script = Path(sys.executable).parent / "switch-interface"
+    eps = metadata.entry_points(group="console_scripts")
+    ep = next(ep for ep in eps if ep.name == "switch-interface")
+    assert ep.value == "switch_interface.launcher:main"
+
     code = (
-        "import os, sys, types, runpy, pathlib\n"
+        "import os, sys, types, runpy\n"
         "os.environ['SI_TEST_MODE'] = '1'\n"
         "sys.modules['sounddevice'] = types.SimpleNamespace()\n"
-        f"runpy.run_path(str(pathlib.Path('{script}')), run_name='__main__')\n"
+        "runpy.run_module('switch_interface.launcher', run_name='__main__')\n"
     )
     result = subprocess.run(
         [sys.executable, "-"],

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -1,12 +1,39 @@
+import os
 import subprocess
 import sys
+from pathlib import Path
 
 
-def test_cli_help():
-    result = subprocess.run(
-        [sys.executable, "-m", "switch_interface", "--help"],
-        capture_output=True,
-        text=True,
+def test_module_uses_launcher():
+    code = (
+        "import sys, types, runpy\n"
+        "sys.modules['sounddevice'] = types.SimpleNamespace()\n"
+        "import switch_interface.launcher as l\n"
+        "l.main = lambda: print('launcher-main-invoked')\n"
+        "runpy.run_module('switch_interface', run_name='__main__')\n"
     )
-    assert result.returncode == 0
-    assert "switch-accessible virtual keyboard" in result.stdout
+    result = subprocess.run(
+        [sys.executable, "-"],
+        input=code,
+        text=True,
+        capture_output=True,
+    )
+    assert result.stdout.strip() == "launcher-main-invoked"
+
+
+def test_console_script_uses_launcher():
+    script = Path(sys.executable).parent / "switch-interface"
+    code = (
+        "import sys, types, runpy, pathlib\n"
+        "sys.modules['sounddevice'] = types.SimpleNamespace()\n"
+        "import switch_interface.launcher as l\n"
+        "l.main = lambda: print('launcher-main-invoked')\n"
+        f"runpy.run_path(str(pathlib.Path('{script}')), run_name='__main__')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-"],
+        input=code,
+        text=True,
+        capture_output=True,
+    )
+    assert result.stdout.strip() == "launcher-main-invoked"

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -6,10 +6,9 @@ from pathlib import Path
 
 def test_module_uses_launcher():
     code = (
-        "import sys, types, runpy\n"
+        "import os, sys, types, runpy\n"
+        "os.environ['SI_TEST_MODE'] = '1'\n"
         "sys.modules['sounddevice'] = types.SimpleNamespace()\n"
-        "import switch_interface.launcher as l\n"
-        "l.main = lambda: print('launcher-main-invoked')\n"
         "runpy.run_module('switch_interface', run_name='__main__')\n"
     )
     result = subprocess.run(
@@ -24,10 +23,9 @@ def test_module_uses_launcher():
 def test_console_script_uses_launcher():
     script = Path(sys.executable).parent / "switch-interface"
     code = (
-        "import sys, types, runpy, pathlib\n"
+        "import os, sys, types, runpy, pathlib\n"
+        "os.environ['SI_TEST_MODE'] = '1'\n"
         "sys.modules['sounddevice'] = types.SimpleNamespace()\n"
-        "import switch_interface.launcher as l\n"
-        "l.main = lambda: print('launcher-main-invoked')\n"
         f"runpy.run_path(str(pathlib.Path('{script}')), run_name='__main__')\n"
     )
     result = subprocess.run(

--- a/tests/test_main_async.py
+++ b/tests/test_main_async.py
@@ -77,7 +77,7 @@ def test_launch_continues_when_device_check_hangs(monkeypatch, caplog):
     monkeypatch.setattr(cli.threading, "Thread", DummyThread)
 
     with caplog.at_level(logging.WARNING):
-        cli.main([])
+        cli.keyboard_main([])
 
     assert "init" in events
     assert "run" in events


### PR DESCRIPTION
## Summary
- update console script mapping to point at `switch_interface.launcher:main`
- delegate `__main__.py` to the launcher and expose `keyboard_main`
- add environment variable hook in `launcher.main` for tests
- adjust modules to call `keyboard_main`
- add entrypoint integration tests

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687436b5cb30833384226ac62e956e6f