### PR TITLE
Implement first-run wizard in launcher

### DIFF
--- a/switch_interface/launcher.py
+++ b/switch_interface/launcher.py
@@ -7,7 +7,8 @@ import tkinter as tk
 from importlib import resources
 from pathlib import Path
 
-from . import __main__, calibration
+from . import __main__, calibration, config
+from .gui import FirstRunWizard
 
 LAYOUT_PACKAGE = "switch_interface.resources.layouts"
 
@@ -27,6 +28,14 @@ def main() -> None:
         print("launcher-main-invoked")
         return
 
+    settings = config.load_settings()
+    if os.getenv("SKIP_FIRST_RUN") != "1" and settings.get("calibration_complete") is False:
+        tmp_root = tk.Tk()
+        tmp_root.withdraw()
+        FirstRunWizard(tmp_root).show_modal()
+        tmp_root.destroy()
+        settings = config.load_settings()
+
     root = tk.Tk()
     root.title("Launch Switch Interface")
 
@@ -35,7 +44,7 @@ def main() -> None:
     if layout_paths:
         layout_var.set(layout_paths[0].name)
 
-    dwell_var = tk.DoubleVar(master=root, value=0.6)
+    dwell_var = tk.DoubleVar(master=root, value=settings.get("scan_interval", 0.6))
     rowcol_var = tk.BooleanVar(master=root, value=False)
 
     tk.Label(root, text="Layout").pack(padx=10, pady=(10, 0))

--- a/tests/test_launcher_wizard.py
+++ b/tests/test_launcher_wizard.py
@@ -1,0 +1,45 @@
+from switch_interface import config
+from tests.test_calibration_ui import _setup_dummy_tk
+import importlib
+import sys
+import types
+
+
+def test_wizard_invoked_first_run(monkeypatch, tmp_path):
+    DummyTk = _setup_dummy_tk(monkeypatch)
+    DummyTk.mainloop = lambda self: None
+    DummyTk.withdraw = lambda self: None
+    sys.modules["tkinter"].BooleanVar = sys.modules["tkinter"].DoubleVar
+    sys.modules["tkinter"].Checkbutton = lambda *a, **k: types.SimpleNamespace(
+        pack=lambda *a, **k: None
+    )
+    sys.modules["tkinter"].RIGHT = "right"
+
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "cfg.json")
+    monkeypatch.setattr(
+        config,
+        "load_settings",
+        lambda path=None: {"calibration_complete": False},
+    )
+
+    called = []
+
+    class DummyWizard:
+        def __init__(self, master=None):
+            called.append("init")
+
+        def show_modal(self):
+            called.append("show")
+
+    dummy_gui = types.SimpleNamespace(FirstRunWizard=DummyWizard)
+    monkeypatch.setitem(sys.modules, "switch_interface.gui", dummy_gui)
+    dummy_calib = types.SimpleNamespace(calibrate=lambda: None)
+    monkeypatch.setitem(sys.modules, "switch_interface.calibration", dummy_calib)
+    dummy_main = types.SimpleNamespace(keyboard_main=lambda *a, **k: None)
+    monkeypatch.setitem(sys.modules, "switch_interface.__main__", dummy_main)
+
+    import switch_interface.launcher as launcher
+    importlib.reload(launcher)
+    launcher.main()
+
+    assert called == ["init", "show"]


### PR DESCRIPTION
## Summary
- integrate settings & first-run wizard in `switch_interface.launcher`
- load saved scanning interval for dwell time
- test wizard is called on first run

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875190f2d088333bf0a176a90ac789d