### PR TITLE
Improve first-run wizard trigger

### DIFF
--- a/switch_interface/app.py
+++ b/switch_interface/app.py
@@ -12,7 +12,7 @@ def main() -> None:
     root = tk.Tk()
     root.withdraw()
     if os.getenv("SKIP_FIRST_RUN") != "1":
-        if settings.get("calibration_complete") is False:
+        if not settings.get("calibration_complete"):
             FirstRunWizard(root).show_modal()
             settings = config.load_settings()
     root.destroy()

--- a/switch_interface/launcher.py
+++ b/switch_interface/launcher.py
@@ -29,7 +29,7 @@ def main() -> None:
         return
 
     settings = config.load_settings()
-    if os.getenv("SKIP_FIRST_RUN") != "1" and settings.get("calibration_complete") is False:
+    if os.getenv("SKIP_FIRST_RUN") != "1" and not settings.get("calibration_complete"):
         tmp_root = tk.Tk()
         tmp_root.withdraw()
         FirstRunWizard(tmp_root).show_modal()

--- a/tests/test_launcher_wizard.py
+++ b/tests/test_launcher_wizard.py
@@ -43,3 +43,39 @@ def test_wizard_invoked_first_run(monkeypatch, tmp_path):
     launcher.main()
 
     assert called == ["init", "show"]
+
+
+def test_wizard_runs_when_setting_missing(monkeypatch, tmp_path):
+    DummyTk = _setup_dummy_tk(monkeypatch)
+    DummyTk.mainloop = lambda self: None
+    DummyTk.withdraw = lambda self: None
+    sys.modules["tkinter"].BooleanVar = sys.modules["tkinter"].DoubleVar
+    sys.modules["tkinter"].Checkbutton = lambda *a, **k: types.SimpleNamespace(
+        pack=lambda *a, **k: None
+    )
+    sys.modules["tkinter"].RIGHT = "right"
+
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "cfg.json")
+    monkeypatch.setattr(config, "load_settings", lambda path=None: {})
+
+    called = []
+
+    class DummyWizard:
+        def __init__(self, master=None):
+            called.append("init")
+
+        def show_modal(self):
+            called.append("show")
+
+    dummy_gui = types.SimpleNamespace(FirstRunWizard=DummyWizard)
+    monkeypatch.setitem(sys.modules, "switch_interface.gui", dummy_gui)
+    dummy_calib = types.SimpleNamespace(calibrate=lambda: None)
+    monkeypatch.setitem(sys.modules, "switch_interface.calibration", dummy_calib)
+    dummy_main = types.SimpleNamespace(keyboard_main=lambda *a, **k: None)
+    monkeypatch.setitem(sys.modules, "switch_interface.__main__", dummy_main)
+
+    import switch_interface.launcher as launcher
+    importlib.reload(launcher)
+    launcher.main()
+
+    assert called == ["init", "show"]


### PR DESCRIPTION
## Summary
- launch first-run wizard whenever calibration_complete is missing or False
- add regression test for missing setting condition

## Testing
- `pip install -r dev-requirements.txt`
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752c55f9e88333ae0399a395ad0980